### PR TITLE
curl-impersonate: fix some compilation errors

### DIFF
--- a/pkgs/by-name/cu/curl-impersonate/curl.patch
+++ b/pkgs/by-name/cu/curl-impersonate/curl.patch
@@ -1,0 +1,4831 @@
+diff --git a/Makefile.am b/Makefile.am
+index d63ef63..9471f8a 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -90,13 +90,13 @@ EXTRA_DIST = CHANGES.md COPYING RELEASE-NOTES Dockerfile \
+ 
+ DISTCLEANFILES = buildinfo.txt
+ 
+-bin_SCRIPTS = curl-config
++bin_SCRIPTS = curl-impersonate-config
+ 
+ SUBDIRS = lib docs src scripts
+ DIST_SUBDIRS = $(SUBDIRS) tests packages include docs
+ 
+ pkgconfigdir = $(libdir)/pkgconfig
+-pkgconfig_DATA = libcurl.pc
++pkgconfig_DATA = libcurl-impersonate.pc
+ 
+ dist-hook:
+ 	rm -rf $(top_builddir)/tests/log
+diff --git a/configure.ac b/configure.ac
+index 7f5a2bf..781dcf3 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1500,7 +1500,8 @@ if test X"$OPT_BROTLI" != Xno; then
+ 
+   dnl if given with a prefix, we set -L and -I based on that
+   if test -n "$PREFIX_BROTLI"; then
+-    LIB_BROTLI="-lbrotlidec"
++    # curl-impersonate: Use static libbrotli, -static postfix dropped since brotli 1.1.0
++    LIB_BROTLI="-lbrotlidec -lbrotlicommon"
+     LD_BROTLI=-L${PREFIX_BROTLI}/lib$libsuff
+     CPP_BROTLI=-I${PREFIX_BROTLI}/include
+     DIR_BROTLI=${PREFIX_BROTLI}/lib$libsuff
+@@ -1511,7 +1512,11 @@ if test X"$OPT_BROTLI" != Xno; then
+   CPPFLAGS="$CPPFLAGS $CPP_BROTLI"
+   LIBS="$LIB_BROTLI $LIBS"
+ 
+-  AC_CHECK_LIB(brotlidec, BrotliDecoderDecompress)
++  AC_CHECK_LIB(brotlidec, BrotliDecoderDecompress,
++    # curl-impersonate: Define 'action-if-found' explicitly to prevent
++    # -lbrotlidec from being added to LIBS (already added before)
++    AC_DEFINE(HAVE_LIBBROTLI, 1, [Define to 1 if libbrotli exists])
++  )
+ 
+   AC_CHECK_HEADERS(brotli/decode.h,
+     curl_brotli_msg="enabled (libbrotlidec)"
+@@ -5362,6 +5367,8 @@ SUPPORT_PROTOCOLS=`echo $SUPPORT_PROTOCOLS | tr ' ' '\012' | sort | tr '\012' '
+ 
+ AC_SUBST(SUPPORT_PROTOCOLS)
+ 
++AC_CHECK_FUNCS([SSL_set_alps_use_new_codepoint])
++
+ dnl squeeze whitespace out of some variables
+ 
+ squeeze CFLAGS
+@@ -5415,8 +5422,8 @@ AC_CONFIG_FILES([\
+   tests/http/clients/Makefile \
+   packages/Makefile \
+   packages/vms/Makefile \
+-  curl-config \
+-  libcurl.pc
++  curl-impersonate-config:curl-config.in \
++  libcurl-impersonate.pc:libcurl.pc.in
+ ])
+ AC_OUTPUT
+ 
+diff --git a/curl-config.in b/curl-config.in
+index 5518416..b0e592d 100644
+--- a/curl-config.in
++++ b/curl-config.in
+@@ -155,9 +155,9 @@ while test "$#" -gt 0; do
+       curllibdir=''
+     fi
+     if test 'X@ENABLE_SHARED@' = 'Xno'; then
+-      echo "${curllibdir}-lcurl @LIBCURL_PC_LIBS_PRIVATE@"
++      echo "${curllibdir}-lcurl-impersonate @LIBCURL_PC_LIBS_PRIVATE@"
+     else
+-      echo "${curllibdir}-lcurl"
++      echo "${curllibdir}-lcurl-impersonate"
+     fi
+     ;;
+ 
+@@ -167,7 +167,7 @@ while test "$#" -gt 0; do
+ 
+   --static-libs)
+     if test 'X@ENABLE_STATIC@' != 'Xno'; then
+-      echo "@libdir@/libcurl.@libext@ @LIBCURL_PC_LDFLAGS_PRIVATE@ @LIBCURL_PC_LIBS_PRIVATE@"
++      echo "@libdir@/libcurl-impersonate.@libext@ @LIBCURL_PC_LDFLAGS_PRIVATE@ @LIBCURL_PC_LIBS_PRIVATE@"
+     else
+       echo 'curl was built with static libraries disabled' >&2
+       exit 1
+diff --git a/include/curl/curl.h b/include/curl/curl.h
+index 84966e8..ab01b94 100644
+--- a/include/curl/curl.h
++++ b/include/curl/curl.h
+@@ -2258,6 +2258,86 @@ typedef enum {
+ 
+   CURLOPT(CURLOPT_UPLOAD_FLAGS, CURLOPTTYPE_LONG, 327),
+ 
++  /* curl-impersonate: A list of headers used by the impersonated browser.
++   * If given, merged with CURLOPT_HTTPHEADER. */
++  CURLOPT(CURLOPT_HTTPBASEHEADER, CURLOPTTYPE_SLISTPOINT, 1000),
++
++  /* curl-impersonate: A list of TLS signature hash algorithms.
++   * See https://datatracker.ietf.org/doc/html/rfc5246#section-7.4.1.4.1 */
++  CURLOPT(CURLOPT_SSL_SIG_HASH_ALGS, CURLOPTTYPE_STRINGPOINT, 1001),
++
++  /* curl-impersonate: Whether to enable ALPS in TLS or not.
++   * See https://datatracker.ietf.org/doc/html/draft-vvv-tls-alps.
++   * Support for ALPS is minimal and is intended only for the TLS client
++   * hello to match. */
++  CURLOPT(CURLOPT_SSL_ENABLE_ALPS, CURLOPTTYPE_LONG, 1002),
++
++  /* curl-impersonate: Comma-separated list of certificate compression
++   * algorithms to use. These are published in the client hello.
++   * Supported algorithms are "zlib" and "brotli".
++   * See https://datatracker.ietf.org/doc/html/rfc8879 */
++  CURLOPT(CURLOPT_SSL_CERT_COMPRESSION, CURLOPTTYPE_STRINGPOINT, 1003),
++
++  /* Enable/disable TLS session ticket extension (RFC5077) */
++  CURLOPT(CURLOPT_SSL_ENABLE_TICKET, CURLOPTTYPE_LONG, 1004),
++
++  /*
++   * curl-impersonate:
++   * Set the order of the HTTP/2 pseudo headers. The value must contain
++   * the letters 'm', 'a', 's', 'p' representing the pseudo-headers
++   * ":method", ":authority", ":scheme", ":path" in the desired order of
++   * appearance in the HTTP/2 HEADERS frame.
++   */
++  CURLOPT(CURLOPT_HTTP2_PSEUDO_HEADERS_ORDER, CURLOPTTYPE_STRINGPOINT, 1005),
++
++  /* curl-impersonate: HTTP2 settings frame keys and values, format: 1:v;2:v;3:v */
++  CURLOPT(CURLOPT_HTTP2_SETTINGS, CURLOPTTYPE_STRINGPOINT, 1006),
++
++  /*
++   * curl-impersonate: Whether to enable Boringssl permute extensions
++   * See https://commondatastorage.googleapis.com/chromium-boringssl-docs/ssl.h.html#SSL_set_permute_extensions.
++   */
++  CURLOPT(CURLOPT_SSL_PERMUTE_EXTENSIONS, CURLOPTTYPE_LONG, 1007),
++
++  /* curl-impersonate: HTTP2 initial window update */
++  CURLOPT(CURLOPT_HTTP2_WINDOW_UPDATE, CURLOPTTYPE_LONG, 1008),
++
++  /* curl-impersonate: Set the initial streams settings for http2. */
++  CURLOPT(CURLOPT_HTTP2_STREAMS, CURLOPTTYPE_STRINGPOINT, 1010),
++
++  /* curl-impersonate: enable tls grease */
++  CURLOPT(CURLOPT_TLS_GREASE, CURLOPTTYPE_LONG, 1011),
++
++  /* curl-impersonate: set tls extension order */
++  CURLOPT(CURLOPT_TLS_EXTENSION_ORDER, CURLOPTTYPE_STRINGPOINT, 1012),
++
++  /* curl-impersonate: Set stream exclusiveness, 0 or 1 */
++  CURLOPT(CURLOPT_STREAM_EXCLUSIVE, CURLOPTTYPE_LONG, 1013),
++
++  /* curl-impersonate: enable tls key usage check, defaults: on */
++  CURLOPT(CURLOPT_TLS_KEY_USAGE_NO_CHECK, CURLOPTTYPE_LONG, 1014),
++
++  /* curl-impersonate: enable tls signed cert stamps */
++  CURLOPT(CURLOPT_TLS_SIGNED_CERT_TIMESTAMPS, CURLOPTTYPE_LONG, 1015),
++
++  /* curl-impersonate: enable tls status request */
++  CURLOPT(CURLOPT_TLS_STATUS_REQUEST, CURLOPTTYPE_LONG, 1016),
++
++  /* curl-impersonate: firefox delegated credentials */
++  CURLOPT(CURLOPT_TLS_DELEGATED_CREDENTIALS, CURLOPTTYPE_STRINGPOINT, 1017),
++
++  /* curl-impersonate: firefox record size limit */
++  CURLOPT(CURLOPT_TLS_RECORD_SIZE_LIMIT, CURLOPTTYPE_LONG, 1018),
++
++  /* curl-impersonate: firefox key_shares_limit */
++  CURLOPT(CURLOPT_TLS_KEY_SHARES_LIMIT, CURLOPTTYPE_LONG, 1019),
++
++  /* curl-impersonate: Use the new ALPS code point */
++  CURLOPT(CURLOPT_TLS_USE_NEW_ALPS_CODEPOINT, CURLOPTTYPE_LONG, 1020),
++
++  /* curl-impersonate: Use firefox tls13 cipher order */
++  CURLOPT(CURLOPT_TLS_USE_FIREFOX_TLS13_CIPHERS, CURLOPTTYPE_LONG, 1021),
++
+   CURLOPT_LASTENTRY /* the last unused */
+ } CURLoption;
+ 
+diff --git a/include/curl/curlver.h b/include/curl/curlver.h
+index a0d7309..95bcb3c 100644
+--- a/include/curl/curlver.h
++++ b/include/curl/curlver.h
+@@ -32,7 +32,7 @@
+ 
+ /* This is the version number of the libcurl package from which this header
+    file origins: */
+-#define LIBCURL_VERSION "8.13.0"
++#define LIBCURL_VERSION "8.13.0-IMPERSONATE"
+ 
+ /* The numeric version number is also available "in parts" by using these
+    defines: */
+diff --git a/include/curl/easy.h b/include/curl/easy.h
+index 56f8060..1a348c5 100644
+--- a/include/curl/easy.h
++++ b/include/curl/easy.h
+@@ -43,6 +43,17 @@ CURL_EXTERN CURLcode curl_easy_setopt(CURL *curl, CURLoption option, ...);
+ CURL_EXTERN CURLcode curl_easy_perform(CURL *curl);
+ CURL_EXTERN void curl_easy_cleanup(CURL *curl);
+ 
++/*
++ * curl-impersonate: Tell libcurl to impersonate a browser.
++ * This is a wrapper function that calls curl_easy_setopt()
++ * multiple times with all the parameters required. That's also why it was
++ * created as a separate API function and not just as another option to
++ * curl_easy_setopt().
++ */
++CURL_EXTERN CURLcode curl_easy_impersonate(CURL *curl, const char *target,
++                                           int default_headers);
++
++
+ /*
+  * NAME curl_easy_getinfo()
+  *
+diff --git a/lib/Makefile.am b/lib/Makefile.am
+index b8aaada..8ad9ce2 100644
+--- a/lib/Makefile.am
++++ b/lib/Makefile.am
+@@ -32,7 +32,7 @@ EXTRA_DIST = config-mac.h config-os400.h config-plan9.h config-riscos.h \
+  config-win32.h curl_config.h.in libcurl.rc libcurl.def                 \
+  $(CMAKE_DIST) Makefile.soname optiontable.pl $(CHECKSRC_DIST)
+ 
+-lib_LTLIBRARIES = libcurl.la
++lib_LTLIBRARIES = libcurl-impersonate.la
+ 
+ if BUILD_UNITTESTS
+ noinst_LTLIBRARIES = libcurlu.la
+@@ -99,58 +99,58 @@ endif
+ libcurl_unity.c: $(top_srcdir)/scripts/mk-unity.pl $(CSOURCES)
+ 	@PERL@ $(top_srcdir)/scripts/mk-unity.pl $(srcdir) $(CSOURCES) --exclude $(curl_EXCLUDE) > libcurl_unity.c
+ 
+-nodist_libcurl_la_SOURCES = libcurl_unity.c
+-libcurl_la_SOURCES = $(curl_EXCLUDE)
++nodist_libcurl_impersonate_la_SOURCES = libcurl_unity.c
++libcurl_impersonate_la_SOURCES = $(curl_EXCLUDE)
+ nodist_libcurlu_la_SOURCES = libcurl_unity.c
+ libcurlu_la_SOURCES = $(curl_EXCLUDE)
+ CLEANFILES = libcurl_unity.c
+ else
+-libcurl_la_SOURCES = $(CSOURCES) $(HHEADERS)
++libcurl_impersonate_la_SOURCES = $(CSOURCES) $(HHEADERS)
+ libcurlu_la_SOURCES = $(CSOURCES) $(HHEADERS)
+ endif
+ 
+-libcurl_la_CPPFLAGS_EXTRA =
+-libcurl_la_LDFLAGS_EXTRA =
+-libcurl_la_CFLAGS_EXTRA =
++libcurl_impersonate_la_CPPFLAGS_EXTRA =
++libcurl_impersonate_la_LDFLAGS_EXTRA =
++libcurl_impersonate_la_CFLAGS_EXTRA =
+ 
+ if CURL_LT_SHLIB_USE_VERSION_INFO
+-libcurl_la_LDFLAGS_EXTRA += $(VERSIONINFO)
++libcurl_impersonate_la_LDFLAGS_EXTRA += $(VERSIONINFO)
+ endif
+ 
+ if CURL_LT_SHLIB_USE_NO_UNDEFINED
+-libcurl_la_LDFLAGS_EXTRA += -no-undefined
++libcurl_impersonate_la_LDFLAGS_EXTRA += -no-undefined
+ endif
+ 
+ if CURL_LT_SHLIB_USE_MIMPURE_TEXT
+-libcurl_la_LDFLAGS_EXTRA += -mimpure-text
++libcurl_impersonate_la_LDFLAGS_EXTRA += -mimpure-text
+ endif
+ 
+ if CURL_LT_SHLIB_USE_VERSIONED_SYMBOLS
+-libcurl_la_LDFLAGS_EXTRA += -Wl,--version-script=libcurl.vers
++libcurl_impersonate_la_LDFLAGS_EXTRA += -Wl,--version-script=libcurl.vers
+ else
+ # if symbol-hiding is enabled, hide them!
+ if DOING_CURL_SYMBOL_HIDING
+-libcurl_la_LDFLAGS_EXTRA += -export-symbols-regex '^curl_.*'
++libcurl_impersonate_la_LDFLAGS_EXTRA += -export-symbols-regex '^curl_.*'
+ endif
+ endif
+ 
+ if USE_CPPFLAG_CURL_STATICLIB
+-libcurl_la_CPPFLAGS_EXTRA += -DCURL_STATICLIB
++libcurl_impersonate_la_CPPFLAGS_EXTRA += -DCURL_STATICLIB
+ else
+ if HAVE_WINDRES
+-libcurl_la_SOURCES += $(LIB_RCFILES)
++libcurl_impersonate_la_SOURCES += $(LIB_RCFILES)
+ $(LIB_RCFILES): $(top_srcdir)/include/curl/curlver.h
+ endif
+ endif
+ 
+ if DOING_CURL_SYMBOL_HIDING
+-libcurl_la_CPPFLAGS_EXTRA += -DCURL_HIDDEN_SYMBOLS
+-libcurl_la_CFLAGS_EXTRA += $(CFLAG_CURL_SYMBOL_HIDING)
++libcurl_impersonate_la_CPPFLAGS_EXTRA += -DCURL_HIDDEN_SYMBOLS
++libcurl_impersonate_la_CFLAGS_EXTRA += $(CFLAG_CURL_SYMBOL_HIDING)
+ endif
+ 
+-libcurl_la_CPPFLAGS = $(AM_CPPFLAGS) $(libcurl_la_CPPFLAGS_EXTRA)
+-libcurl_la_LDFLAGS = $(AM_LDFLAGS) $(libcurl_la_LDFLAGS_EXTRA) $(CURL_LDFLAGS_LIB) $(LIBCURL_PC_LIBS_PRIVATE)
+-libcurl_la_CFLAGS = $(AM_CFLAGS) $(libcurl_la_CFLAGS_EXTRA)
++libcurl_impersonate_la_CPPFLAGS = $(AM_CPPFLAGS) $(libcurl_impersonate_la_CPPFLAGS_EXTRA)
++libcurl_impersonate_la_LDFLAGS = $(AM_LDFLAGS) $(libcurl_impersonate_la_LDFLAGS_EXTRA) $(CURL_LDFLAGS_LIB) $(LIBCURL_PC_LIBS_PRIVATE)
++libcurl_impersonate_la_CFLAGS = $(AM_CFLAGS) $(libcurl_impersonate_la_CFLAGS_EXTRA)
+ 
+ libcurlu_la_CPPFLAGS = $(AM_CPPFLAGS) -DCURL_STATICLIB -DUNITTESTS
+ libcurlu_la_LDFLAGS = $(AM_LDFLAGS) -static $(LIBCURL_PC_LIBS_PRIVATE)
+diff --git a/lib/Makefile.inc b/lib/Makefile.inc
+index a8e4da1..e3b315b 100644
+--- a/lib/Makefile.inc
++++ b/lib/Makefile.inc
+@@ -185,6 +185,7 @@ LIB_CFILES =         \
+   idn.c              \
+   if2ip.c            \
+   imap.c             \
++  impersonate.c      \
+   inet_ntop.c        \
+   inet_pton.c        \
+   krb5.c             \
+diff --git a/lib/dynhds.c b/lib/dynhds.c
+index 2c92ca6..5694a8e 100644
+--- a/lib/dynhds.c
++++ b/lib/dynhds.c
+@@ -56,6 +56,9 @@ entry_new(const char *name, size_t namelen,
+   e->valuelen = valuelen;
+   if(opts & DYNHDS_OPT_LOWERCASE)
+     Curl_strntolower(e->name, e->name, e->namelen);
++  // curl-impersonate: Make header value also lower case
++  if(opts & DYNHDS_OPT_LOWERCASE_VAL)
++    Curl_strntolower(e->value, e->value, e->valuelen);
+   return e;
+ }
+ 
+@@ -138,6 +141,19 @@ void Curl_dynhds_set_opts(struct dynhds *dynhds, int opts)
+   dynhds->opts = opts;
+ }
+ 
++// curl-impersonate
++void Curl_dynhds_set_opt(struct dynhds *dynhds, int opt)
++{
++  dynhds->opts |= opt;
++}
++
++// curl-impersonate
++void Curl_dynhds_del_opt(struct dynhds *dynhds, int opt)
++{
++  dynhds->opts &= ~opt;
++}
++
++
+ struct dynhds_entry *Curl_dynhds_getn(struct dynhds *dynhds, size_t n)
+ {
+   DEBUGASSERT(dynhds);
+@@ -175,7 +191,7 @@ CURLcode Curl_dynhds_add(struct dynhds *dynhds,
+   if(dynhds->strs_len + namelen + valuelen > dynhds->max_strs_size)
+     return CURLE_OUT_OF_MEMORY;
+ 
+-entry = entry_new(name, namelen, value, valuelen, dynhds->opts);
++  entry = entry_new(name, namelen, value, valuelen, dynhds->opts);
+   if(!entry)
+     goto out;
+ 
+diff --git a/lib/dynhds.h b/lib/dynhds.h
+index fb162a3..f1429fe 100644
+--- a/lib/dynhds.h
++++ b/lib/dynhds.h
+@@ -53,6 +53,7 @@ struct dynhds {
+ 
+ #define DYNHDS_OPT_NONE          (0)
+ #define DYNHDS_OPT_LOWERCASE     (1 << 0)
++#define DYNHDS_OPT_LOWERCASE_VAL (1 << 1)
+ 
+ /**
+  * Init for use on first time or after a reset.
+@@ -82,6 +83,9 @@ size_t Curl_dynhds_count(struct dynhds *dynhds);
+  * This will not have an effect on already existing headers.
+  */
+ void Curl_dynhds_set_opts(struct dynhds *dynhds, int opts);
++// curl-impersonate
++void Curl_dynhds_set_opt(struct dynhds *dynhds, int opt);
++void Curl_dynhds_del_opt(struct dynhds *dynhds, int opt);
+ 
+ /**
+  * Return the n-th header entry or NULL if it does not exist.
+@@ -99,7 +103,7 @@ struct dynhds_entry *Curl_dynhds_cget(struct dynhds *dynhds, const char *name);
+ /* used by unit2602.c */
+ 
+ /**
+- * Return TRUE iff one or more headers with the given name exist.
++ * Return TRUE if one or more headers with the given name exist.
+  */
+ bool Curl_dynhds_contains(struct dynhds *dynhds,
+                           const char *name, size_t namelen);
+diff --git a/lib/easy.c b/lib/easy.c
+index aa1bede..6467d50 100644
+--- a/lib/easy.c
++++ b/lib/easy.c
+@@ -75,6 +75,7 @@
+ #include "dynbuf.h"
+ #include "altsvc.h"
+ #include "hsts.h"
++#include "strcase.h"
+ 
+ #include "easy_lock.h"
+ 
+@@ -344,6 +345,281 @@ CURLsslset curl_global_sslset(curl_sslbackend id, const char *name,
+   return rc;
+ }
+ 
++
++
++/*
++ * curl-impersonate:
++ * Actually call curl_easy_setopt() with all the needed options
++ * */
++static CURLcode _do_impersonate(struct Curl_easy *data,
++                        const struct impersonate_opts *opts,
++                        int default_headers)
++{
++  int i;
++  int ret;
++  struct curl_slist *headers = NULL;
++
++  if(opts->target == NULL) {
++    DEBUGF(fprintf(stderr, "Error: unknown impersonation target '%s'\n",
++                   opts->target));
++    return CURLE_BAD_FUNCTION_ARGUMENT;
++  }
++
++  if(opts->httpversion != CURL_HTTP_VERSION_NONE) {
++    ret = curl_easy_setopt(data, CURLOPT_HTTP_VERSION, opts->httpversion);
++    if(ret)
++      return ret;
++  }
++
++  if (opts->ssl_version != CURL_SSLVERSION_DEFAULT) {
++    ret = curl_easy_setopt(data, CURLOPT_SSLVERSION, opts->ssl_version);
++    if(ret)
++      return ret;
++  }
++
++  if(opts->ciphers) {
++    ret = curl_easy_setopt(data, CURLOPT_SSL_CIPHER_LIST, opts->ciphers);
++    if (ret)
++      return ret;
++  }
++
++  if(opts->curves) {
++    ret = curl_easy_setopt(data, CURLOPT_SSL_EC_CURVES, opts->curves);
++    if(ret)
++      return ret;
++  }
++
++  if(opts->sig_hash_algs) {
++    ret = curl_easy_setopt(data, CURLOPT_SSL_SIG_HASH_ALGS,
++                           opts->sig_hash_algs);
++    if(ret)
++      return ret;
++  }
++
++  ret = curl_easy_setopt(data, CURLOPT_SSL_ENABLE_NPN, opts->npn ? 1 : 0);
++  if(ret)
++    return ret;
++
++  ret = curl_easy_setopt(data, CURLOPT_SSL_ENABLE_ALPN, opts->alpn ? 1 : 0);
++  if(ret)
++    return ret;
++
++  ret = curl_easy_setopt(data, CURLOPT_SSL_ENABLE_ALPS, opts->alps ? 1 : 0);
++  if(ret)
++    return ret;
++
++  ret = curl_easy_setopt(data, CURLOPT_SSL_ENABLE_TICKET,
++                         opts->tls_session_ticket ? 1 : 0);
++  if(ret)
++    return ret;
++
++  // always enable this for browsers
++  ret = curl_easy_setopt(data, CURLOPT_TLS_SIGNED_CERT_TIMESTAMPS, 1);
++  if(ret)
++    return ret;
++
++  // always enable this for browsers
++  ret = curl_easy_setopt(data, CURLOPT_TLS_STATUS_REQUEST, 1);
++  if(ret)
++    return ret;
++
++  if(opts->tls_permute_extensions) {
++    ret = curl_easy_setopt(data, CURLOPT_SSL_PERMUTE_EXTENSIONS, 1);
++    if(ret)
++      return ret;
++  }
++
++  if(opts->cert_compression) {
++    ret = curl_easy_setopt(data,
++                           CURLOPT_SSL_CERT_COMPRESSION,
++                           opts->cert_compression);
++    if(ret)
++      return ret;
++  }
++
++  if(default_headers) {
++    /* Build a linked list out of the static array of headers. */
++    for(i = 0; i < IMPERSONATE_MAX_HEADERS; i++) {
++      if(opts->http_headers[i]) {
++        headers = curl_slist_append(headers, opts->http_headers[i]);
++        if(!headers) {
++          return CURLE_OUT_OF_MEMORY;
++        }
++      }
++    }
++
++    if(headers) {
++      ret = curl_easy_setopt(data, CURLOPT_HTTPBASEHEADER, headers);
++      curl_slist_free_all(headers);
++      if(ret)
++        return ret;
++    }
++  }
++
++  if(opts->http2_pseudo_headers_order) {
++    ret = curl_easy_setopt(data,
++                           CURLOPT_HTTP2_PSEUDO_HEADERS_ORDER,
++                           opts->http2_pseudo_headers_order);
++    if(ret)
++      return ret;
++  }
++
++  if(opts->http2_settings) {
++    ret = curl_easy_setopt(data, CURLOPT_HTTP2_SETTINGS, opts->http2_settings);
++    if(ret)
++      return ret;
++  }
++
++  if(opts->http2_window_update) {
++    ret = curl_easy_setopt(data, CURLOPT_HTTP2_WINDOW_UPDATE, opts->http2_window_update);
++    if(ret)
++      return ret;
++  }
++
++  if(opts->http2_streams) {
++    ret = curl_easy_setopt(data, CURLOPT_HTTP2_STREAMS, opts->http2_streams);
++    if(ret)
++      return ret;
++  }
++
++  if(opts->ech) {
++    ret = curl_easy_setopt(data, CURLOPT_ECH, opts->ech);
++    if(ret)
++      return ret;
++  }
++
++  ret = curl_easy_setopt(data, CURLOPT_TLS_GREASE, opts->tls_grease);
++  if(ret)
++    return ret;
++
++  if(opts->tls_extension_order) {
++    ret = curl_easy_setopt(data, CURLOPT_TLS_EXTENSION_ORDER, opts->tls_extension_order);
++    if(ret)
++      return ret;
++  }
++
++  if(opts->tls_delegated_credentials) {
++    ret = curl_easy_setopt(data, CURLOPT_TLS_DELEGATED_CREDENTIALS, opts->tls_delegated_credentials);
++    if(ret)
++      return ret;
++  }
++
++  if(opts->tls_record_size_limit) {
++    ret = curl_easy_setopt(data, CURLOPT_TLS_RECORD_SIZE_LIMIT, opts->tls_record_size_limit);
++    if(ret)
++      return ret;
++  }
++
++  if(opts->tls_key_shares_limit) {
++    ret = curl_easy_setopt(data, CURLOPT_TLS_KEY_SHARES_LIMIT, opts->tls_key_shares_limit);
++    if(ret)
++      return ret;
++  }
++
++  if(opts->tls_use_new_alps_codepoint) {
++    ret = curl_easy_setopt(data, CURLOPT_TLS_USE_NEW_ALPS_CODEPOINT, opts->tls_use_new_alps_codepoint);
++    if(ret)
++      return ret;
++  }
++
++  if(opts->use_firefox_tls13_ciphers) {
++    ret = curl_easy_setopt(data, CURLOPT_TLS_USE_FIREFOX_TLS13_CIPHERS, opts->use_firefox_tls13_ciphers);
++    if(ret)
++      return ret;
++  }
++
++  if(opts->http2_stream_weight) {
++    ret = curl_easy_setopt(data, CURLOPT_STREAM_WEIGHT, opts->http2_stream_weight);
++    if(ret)
++      return ret;
++  }
++
++  if(opts->http2_stream_exclusive) {
++    ret = curl_easy_setopt(data, CURLOPT_STREAM_EXCLUSIVE, opts->http2_stream_exclusive);
++    if(ret)
++      return ret;
++  }
++
++  return CURLE_OK;
++}
++
++
++/*
++ * curl-impersonate:
++ * Call curl_easy_setopt() with all the needed options as defined by the target
++ * */
++CURLcode curl_easy_impersonate_customized(struct Curl_easy *data,
++                                          const struct impersonate_opts *opts,
++                                          int default_headers)
++{
++  int ret;
++
++  ret = _do_impersonate(data, opts, default_headers);
++  if(ret)
++    return ret;
++
++  return CURLE_OK;
++}
++
++
++static const struct impersonate_opts *binary_search(size_t size, const char *key)
++{
++  int low = 0;
++  int high = size - 1;
++
++  while(low <= high) {
++    int mid = low + (high - low) / 2;
++    int cmp = strcmp(impersonations[mid].target, key);
++
++    if(cmp == 0) {
++      return &impersonations[mid];
++    } else if(cmp < 0) {
++      low = mid + 1;
++    } else {
++      high = mid - 1;
++    }
++  }
++
++  return NULL;
++}
++
++/*
++ * curl-impersonate:
++ * Call curl_easy_setopt() with all the needed options as defined in the
++ * 'impersonations' array.
++ * */
++CURLcode curl_easy_impersonate(CURL *data, const char *target,
++                               int default_headers)
++{
++  int ret;
++  const struct impersonate_opts *opts = NULL;
++  struct Curl_easy *_data = (struct Curl_easy *)data;
++
++  opts = binary_search(num_impersonations, target);
++
++  // If not found, fallback and search by alias again
++  if(opts == NULL) {
++    for(int i = 0; i < num_impersonations; ++i) {
++      if (strcasecompare(target, impersonations[i].alias)) {
++        opts = impersonations + i;
++        break;
++      }
++    }
++  }
++
++  if(opts == NULL) {
++    DEBUGF(fprintf(stderr, "Error: unknown impersonation target '%s'\n", target));
++    return CURLE_BAD_FUNCTION_ARGUMENT;
++  }
++
++  ret = _do_impersonate(_data, opts, default_headers);
++  if(ret)
++    return ret;
++
++  return CURLE_OK;
++}
++
++
+ /*
+  * curl_easy_init() is the external interface to alloc, setup and init an
+  * easy handle that is returned. If anything goes wrong, NULL is returned.
+@@ -352,6 +628,8 @@ CURL *curl_easy_init(void)
+ {
+   CURLcode result;
+   struct Curl_easy *data;
++  char *env_target = NULL;
++  char *env_headers = NULL;
+ 
+   /* Make sure we inited the global SSL stuff */
+   global_init_lock();
+@@ -374,6 +652,29 @@ CURL *curl_easy_init(void)
+     return NULL;
+   }
+ 
++  /*
++   * curl-impersonate: Hook into curl_easy_init() to set the required options
++   * from an environment variable.
++   * This is a bit hacky but allows seamless integration of libcurl-impersonate
++   * without code modifications to the app.
++   */
++  env_target = curl_getenv("CURL_IMPERSONATE");
++  if(env_target) {
++    env_headers = curl_getenv("CURL_IMPERSONATE_HEADERS");
++    if(env_headers) {
++      result = curl_easy_impersonate(data, env_target,
++                                     !strcasecompare(env_headers, "no"));
++      free(env_headers);
++    } else {
++      result = curl_easy_impersonate(data, env_target, true);
++    }
++    free(env_target);
++    if(result) {
++      Curl_close(&data);
++      return NULL;
++    }
++  }
++
+   return data;
+ }
+ 
+@@ -1010,6 +1311,13 @@ CURL *curl_easy_duphandle(CURL *d)
+     outcurl->state.referer_alloc = TRUE;
+   }
+ 
++  if(data->state.base_headers) {
++    outcurl->state.base_headers =
++      Curl_slist_duplicate(data->state.base_headers);
++    if(!outcurl->state.base_headers)
++      goto fail;
++  }
++
+   /* Reinitialize an SSL engine for the new handle
+    * note: the engine name has already been copied by dupset */
+   if(outcurl->set.str[STRING_SSL_ENGINE]) {
+@@ -1096,6 +1404,9 @@ fail:
+  */
+ void curl_easy_reset(CURL *d)
+ {
++  char *env_target;
++  char *env_headers;
++
+   struct Curl_easy *data = d;
+   Curl_req_hard_reset(&data->req, data);
+ 
+@@ -1121,6 +1432,23 @@ void curl_easy_reset(CURL *d)
+ #if !defined(CURL_DISABLE_HTTP) && !defined(CURL_DISABLE_DIGEST_AUTH)
+   Curl_http_auth_cleanup_digest(data);
+ #endif
++
++  /*
++   * curl-impersonate: Hook into curl_easy_reset() to set the required options
++   * from an environment variable, just like in curl_easy_init().
++   */
++  env_target = curl_getenv("CURL_IMPERSONATE");
++  if(env_target) {
++    env_headers = curl_getenv("CURL_IMPERSONATE_HEADERS");
++    if(env_headers) {
++      curl_easy_impersonate(data, env_target,
++                            !strcasecompare(env_headers, "no"));
++      free(env_headers);
++    } else {
++      curl_easy_impersonate(data, env_target, true);
++    }
++    free(env_target);
++  }
+ }
+ 
+ /*
+@@ -1398,3 +1726,1678 @@ CURLcode curl_easy_ssls_export(CURL *d,
+   return CURLE_NOT_BUILT_IN;
+ #endif
+ }
++
++const struct impersonate_opts impersonations[] = {
++  {
++    .target = "chrome100",
++    .alias = "chrome100",
++    .httpversion = CURL_HTTP_VERSION_2_0,
++    .ssl_version = CURL_SSLVERSION_TLSv1_2 | CURL_SSLVERSION_MAX_DEFAULT,
++    .ciphers =
++    "TLS_AES_128_GCM_SHA256,"
++    "TLS_AES_256_GCM_SHA384,"
++    "TLS_CHACHA20_POLY1305_SHA256,"
++    "ECDHE-ECDSA-AES128-GCM-SHA256,"
++    "ECDHE-RSA-AES128-GCM-SHA256,"
++    "ECDHE-ECDSA-AES256-GCM-SHA384,"
++    "ECDHE-RSA-AES256-GCM-SHA384,"
++    "ECDHE-ECDSA-CHACHA20-POLY1305,"
++    "ECDHE-RSA-CHACHA20-POLY1305,"
++    "ECDHE-RSA-AES128-SHA,"
++    "ECDHE-RSA-AES256-SHA,"
++    "AES128-GCM-SHA256,"
++    "AES256-GCM-SHA384,"
++    "AES128-SHA,"
++    "AES256-SHA",
++    .npn = false,
++    .alpn = true,
++    .alps = true,
++    .tls_session_ticket = true,
++    .cert_compression = "brotli",
++    .http_headers = {
++      "sec-ch-ua: \" Not A;Brand\";v=\"99\", \"Chromium\";v=\"100\", \"Google Chrome\";v=\"100\"",
++      "sec-ch-ua-mobile: ?0",
++      "sec-ch-ua-platform: \"Windows\"",
++      "Upgrade-Insecure-Requests: 1",
++      "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.75 Safari/537.36",
++      "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
++      "Sec-Fetch-Site: none",
++      "Sec-Fetch-Mode: navigate",
++      "Sec-Fetch-User: ?1",
++      "Sec-Fetch-Dest: document",
++      "Accept-Encoding: gzip, deflate, br",
++      "Accept-Language: en-US,en;q=0.9"
++    },
++    .http2_settings = "1:65536;3:1000;4:6291456;6:262144",
++    .http2_window_update = 15663105,
++    .http2_stream_weight = 256,
++    .http2_stream_exclusive = 1,
++    .tls_extension_order = NULL,
++    .tls_use_new_alps_codepoint = false,
++    .tls_signed_cert_timestamps = true,
++    .tls_grease = true
++  },
++  {
++    .target = "chrome101",
++    .alias = "chrome101",
++    .httpversion = CURL_HTTP_VERSION_2_0,
++    .ssl_version = CURL_SSLVERSION_TLSv1_2 | CURL_SSLVERSION_MAX_DEFAULT,
++    .ciphers =
++    "TLS_AES_128_GCM_SHA256,"
++    "TLS_AES_256_GCM_SHA384,"
++    "TLS_CHACHA20_POLY1305_SHA256,"
++    "ECDHE-ECDSA-AES128-GCM-SHA256,"
++    "ECDHE-RSA-AES128-GCM-SHA256,"
++    "ECDHE-ECDSA-AES256-GCM-SHA384,"
++    "ECDHE-RSA-AES256-GCM-SHA384,"
++    "ECDHE-ECDSA-CHACHA20-POLY1305,"
++    "ECDHE-RSA-CHACHA20-POLY1305,"
++    "ECDHE-RSA-AES128-SHA,"
++    "ECDHE-RSA-AES256-SHA,"
++    "AES128-GCM-SHA256,"
++    "AES256-GCM-SHA384,"
++    "AES128-SHA,"
++    "AES256-SHA",
++    .npn = false,
++    .alpn = true,
++    .alps = true,
++    .tls_session_ticket = true,
++    .cert_compression = "brotli",
++    .http_headers = {
++      "sec-ch-ua: \" Not A;Brand\";v=\"99\", \"Chromium\";v=\"101\", \"Google Chrome\";v=\"101\"",
++      "sec-ch-ua-mobile: ?0",
++      "sec-ch-ua-platform: \"Windows\"",
++      "Upgrade-Insecure-Requests: 1",
++      "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.67 Safari/537.36",
++      "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
++      "Sec-Fetch-Site: none",
++      "Sec-Fetch-Mode: navigate",
++      "Sec-Fetch-User: ?1",
++      "Sec-Fetch-Dest: document",
++      "Accept-Encoding: gzip, deflate, br",
++      "Accept-Language: en-US,en;q=0.9"
++    },
++    .http2_settings = "1:65536;3:1000;4:6291456;6:262144",
++    .http2_window_update = 15663105,
++    .http2_stream_weight = 256,
++    .http2_stream_exclusive = 1,
++    .tls_extension_order = NULL,
++    .tls_use_new_alps_codepoint = false,
++    .tls_signed_cert_timestamps = true,
++    .tls_grease = true
++  },
++  {
++    .target = "chrome104",
++    .alias = "chrome104",
++    .httpversion = CURL_HTTP_VERSION_2_0,
++    .ssl_version = CURL_SSLVERSION_TLSv1_2 | CURL_SSLVERSION_MAX_DEFAULT,
++    .ciphers =
++    "TLS_AES_128_GCM_SHA256,"
++    "TLS_AES_256_GCM_SHA384,"
++    "TLS_CHACHA20_POLY1305_SHA256,"
++    "ECDHE-ECDSA-AES128-GCM-SHA256,"
++    "ECDHE-RSA-AES128-GCM-SHA256,"
++    "ECDHE-ECDSA-AES256-GCM-SHA384,"
++    "ECDHE-RSA-AES256-GCM-SHA384,"
++    "ECDHE-ECDSA-CHACHA20-POLY1305,"
++    "ECDHE-RSA-CHACHA20-POLY1305,"
++    "ECDHE-RSA-AES128-SHA,"
++    "ECDHE-RSA-AES256-SHA,"
++    "AES128-GCM-SHA256,"
++    "AES256-GCM-SHA384,"
++    "AES128-SHA,"
++    "AES256-SHA",
++    .npn = false,
++    .alpn = true,
++    .alps = true,
++    .tls_session_ticket = true,
++    .cert_compression = "brotli",
++    .http_headers = {
++      "sec-ch-ua: \"Chromium\";v=\"104\", \" Not A;Brand\";v=\"99\", \"Google Chrome\";v=\"104\"",
++      "sec-ch-ua-mobile: ?0",
++      "sec-ch-ua-platform: \"Windows\"",
++      "Upgrade-Insecure-Requests: 1",
++      "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Safari/537.36",
++      "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
++      "Sec-Fetch-Site: none",
++      "Sec-Fetch-Mode: navigate",
++      "Sec-Fetch-User: ?1",
++      "Sec-Fetch-Dest: document",
++      "Accept-Encoding: gzip, deflate, br",
++      "Accept-Language: en-US,en;q=0.9"
++    },
++    .http2_settings = "1:65536;3:1000;4:6291456;6:262144",
++    .http2_window_update = 15663105,
++    .http2_stream_weight = 256,
++    .http2_stream_exclusive = 1,
++    .tls_extension_order = NULL,
++    .tls_use_new_alps_codepoint = false,
++    .tls_signed_cert_timestamps = true,
++    .tls_grease = true
++  },
++  {
++    .target = "chrome107",
++    .alias = "chrome107",
++    .httpversion = CURL_HTTP_VERSION_2_0,
++    .ssl_version = CURL_SSLVERSION_TLSv1_2 | CURL_SSLVERSION_MAX_DEFAULT,
++    .ciphers =
++    "TLS_AES_128_GCM_SHA256,"
++    "TLS_AES_256_GCM_SHA384,"
++    "TLS_CHACHA20_POLY1305_SHA256,"
++    "ECDHE-ECDSA-AES128-GCM-SHA256,"
++    "ECDHE-RSA-AES128-GCM-SHA256,"
++    "ECDHE-ECDSA-AES256-GCM-SHA384,"
++    "ECDHE-RSA-AES256-GCM-SHA384,"
++    "ECDHE-ECDSA-CHACHA20-POLY1305,"
++    "ECDHE-RSA-CHACHA20-POLY1305,"
++    "ECDHE-RSA-AES128-SHA,"
++    "ECDHE-RSA-AES256-SHA,"
++    "AES128-GCM-SHA256,"
++    "AES256-GCM-SHA384,"
++    "AES128-SHA,"
++    "AES256-SHA",
++    .npn = false,
++    .alpn = true,
++    .alps = true,
++    .tls_session_ticket = true,
++    .cert_compression = "brotli",
++    .http_headers = {
++      "sec-ch-ua: \"Google Chrome\";v=\"107\", \"Chromium\";v=\"107\", \"Not=A?Brand\";v=\"24\"",
++      "sec-ch-ua-mobile: ?0",
++      "sec-ch-ua-platform: \"Windows\"",
++      "Upgrade-Insecure-Requests: 1",
++      "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36",
++      "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
++      "Sec-Fetch-Site: none",
++      "Sec-Fetch-Mode: navigate",
++      "Sec-Fetch-User: ?1",
++      "Sec-Fetch-Dest: document",
++      "Accept-Encoding: gzip, deflate, br",
++      "Accept-Language: en-US,en;q=0.9"
++    },
++    .http2_settings = "1:65536;2:0;3:1000;4:6291456;6:262144",
++    .http2_window_update = 15663105,
++    .http2_stream_weight = 256,
++    .http2_stream_exclusive = 1,
++    .tls_extension_order = NULL,
++    .tls_use_new_alps_codepoint = false,
++    .tls_signed_cert_timestamps = true,
++    .tls_grease = true
++  },
++  {
++    .target = "chrome110",
++    .alias = "chrome110",
++    .httpversion = CURL_HTTP_VERSION_2_0,
++    .ssl_version = CURL_SSLVERSION_TLSv1_2 | CURL_SSLVERSION_MAX_DEFAULT,
++    .ciphers =
++    "TLS_AES_128_GCM_SHA256,"
++    "TLS_AES_256_GCM_SHA384,"
++    "TLS_CHACHA20_POLY1305_SHA256,"
++    "ECDHE-ECDSA-AES128-GCM-SHA256,"
++    "ECDHE-RSA-AES128-GCM-SHA256,"
++    "ECDHE-ECDSA-AES256-GCM-SHA384,"
++    "ECDHE-RSA-AES256-GCM-SHA384,"
++    "ECDHE-ECDSA-CHACHA20-POLY1305,"
++    "ECDHE-RSA-CHACHA20-POLY1305,"
++    "ECDHE-RSA-AES128-SHA,"
++    "ECDHE-RSA-AES256-SHA,"
++    "AES128-GCM-SHA256,"
++    "AES256-GCM-SHA384,"
++    "AES128-SHA,"
++    "AES256-SHA",
++    .npn = false,
++    .alpn = true,
++    .alps = true,
++    .tls_permute_extensions = true,
++    .tls_session_ticket = true,
++    .cert_compression = "brotli",
++    .http_headers = {
++      "sec-ch-ua: \"Chromium\";v=\"110\", \"Not A(Brand\";v=\"24\", \"Google Chrome\";v=\"110\"",
++      "sec-ch-ua-mobile: ?0",
++      "sec-ch-ua-platform: \"Windows\"",
++      "Upgrade-Insecure-Requests: 1",
++      "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/110.0.0.0 Safari/537.36",
++      "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
++      "Sec-Fetch-Site: none",
++      "Sec-Fetch-Mode: navigate",
++      "Sec-Fetch-User: ?1",
++      "Sec-Fetch-Dest: document",
++      "Accept-Encoding: gzip, deflate, br",
++      "Accept-Language: en-US,en;q=0.9"
++    },
++    .http2_settings = "1:65536;2:0;3:1000;4:6291456;6:262144",
++    .http2_window_update = 15663105,
++    .http2_stream_weight = 256,
++    .http2_stream_exclusive = 1,
++    .tls_extension_order = NULL,
++    .tls_use_new_alps_codepoint = false,
++    .tls_signed_cert_timestamps = true,
++    .tls_grease = true
++  },
++  {
++    .target = "chrome116",
++    .alias = "chrome116",
++    .httpversion = CURL_HTTP_VERSION_2_0,
++    .ssl_version = CURL_SSLVERSION_TLSv1_2 | CURL_SSLVERSION_MAX_DEFAULT,
++    .ciphers =
++    "TLS_AES_128_GCM_SHA256,"
++    "TLS_AES_256_GCM_SHA384,"
++    "TLS_CHACHA20_POLY1305_SHA256,"
++    "ECDHE-ECDSA-AES128-GCM-SHA256,"
++    "ECDHE-RSA-AES128-GCM-SHA256,"
++    "ECDHE-ECDSA-AES256-GCM-SHA384,"
++    "ECDHE-RSA-AES256-GCM-SHA384,"
++    "ECDHE-ECDSA-CHACHA20-POLY1305,"
++    "ECDHE-RSA-CHACHA20-POLY1305,"
++    "ECDHE-RSA-AES128-SHA,"
++    "ECDHE-RSA-AES256-SHA,"
++    "AES128-GCM-SHA256,"
++    "AES256-GCM-SHA384,"
++    "AES128-SHA,"
++    "AES256-SHA",
++    .npn = false,
++    .alpn = true,
++    .alps = true,
++    .tls_permute_extensions = true,
++    .tls_session_ticket = true,
++    .cert_compression = "brotli",
++    .http_headers = {
++      "sec-ch-ua: \"Chromium\";v=\"116\", \"Not)A;Brand\";v=\"24\", \"Google Chrome\";v=\"116\"",
++      "sec-ch-ua-mobile: ?0",
++      "sec-ch-ua-platform: \"Windows\"",
++      "Upgrade-Insecure-Requests: 1",
++      "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36",
++      "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
++      "Sec-Fetch-Site: none",
++      "Sec-Fetch-Mode: navigate",
++      "Sec-Fetch-User: ?1",
++      "Sec-Fetch-Dest: document",
++      "Accept-Encoding: gzip, deflate, br",
++      "Accept-Language: en-US,en;q=0.9"
++    },
++    .http2_settings = "1:65536;2:0;3:1000;4:6291456;6:262144",
++    .http2_window_update = 15663105,
++    .http2_stream_weight = 256,
++    .http2_stream_exclusive = 1,
++    .tls_extension_order = NULL,
++    .tls_use_new_alps_codepoint = false,
++    .tls_signed_cert_timestamps = true,
++    .tls_grease = true
++  },
++  {
++    .target = "chrome119",
++    .alias = "chrome119",
++    .httpversion = CURL_HTTP_VERSION_2_0,
++    .ssl_version = CURL_SSLVERSION_TLSv1_2 | CURL_SSLVERSION_MAX_DEFAULT,
++    .ciphers =
++    "TLS_AES_128_GCM_SHA256,"
++    "TLS_AES_256_GCM_SHA384,"
++    "TLS_CHACHA20_POLY1305_SHA256,"
++    "ECDHE-ECDSA-AES128-GCM-SHA256,"
++    "ECDHE-RSA-AES128-GCM-SHA256,"
++    "ECDHE-ECDSA-AES256-GCM-SHA384,"
++    "ECDHE-RSA-AES256-GCM-SHA384,"
++    "ECDHE-ECDSA-CHACHA20-POLY1305,"
++    "ECDHE-RSA-CHACHA20-POLY1305,"
++    "ECDHE-RSA-AES128-SHA,"
++    "ECDHE-RSA-AES256-SHA,"
++    "AES128-GCM-SHA256,"
++    "AES256-GCM-SHA384,"
++    "AES128-SHA,"
++    "AES256-SHA",
++    .npn = false,
++    .alpn = true,
++    .alps = true,
++    .tls_permute_extensions = true,
++    .tls_session_ticket = true,
++    .cert_compression = "brotli",
++    .http_headers = {
++      "sec-ch-ua: \"Google Chrome\";v=\"119\", \"Chromium\";v=\"119\", \"Not?A_Brand\";v=\"24\"",
++      "sec-ch-ua-mobile: ?0",
++      "sec-ch-ua-platform: \"macOS\"",
++      "Upgrade-Insecure-Requests: 1",
++      "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36",
++      "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
++      "Sec-Fetch-Site: none",
++      "Sec-Fetch-Mode: navigate",
++      "Sec-Fetch-User: ?1",
++      "Sec-Fetch-Dest: document",
++      "Accept-Encoding: gzip, deflate, br",
++      "Accept-Language: en-US,en;q=0.9"
++    },
++    .http2_settings = "1:65536;2:0;4:6291456;6:262144",
++    .http2_window_update = 15663105,
++    .http2_stream_weight = 256,
++    .http2_stream_exclusive = 1,
++    .ech = "grease",
++    .tls_extension_order = NULL,
++    .tls_use_new_alps_codepoint = false,
++    .tls_signed_cert_timestamps = true,
++    .tls_grease = true
++  },
++  {
++    .target = "chrome120",
++    .alias = "chrome120",
++    .httpversion = CURL_HTTP_VERSION_2_0,
++    .ssl_version = CURL_SSLVERSION_TLSv1_2 | CURL_SSLVERSION_MAX_DEFAULT,
++    .ciphers =
++    "TLS_AES_128_GCM_SHA256,"
++    "TLS_AES_256_GCM_SHA384,"
++    "TLS_CHACHA20_POLY1305_SHA256,"
++    "ECDHE-ECDSA-AES128-GCM-SHA256,"
++    "ECDHE-RSA-AES128-GCM-SHA256,"
++    "ECDHE-ECDSA-AES256-GCM-SHA384,"
++    "ECDHE-RSA-AES256-GCM-SHA384,"
++    "ECDHE-ECDSA-CHACHA20-POLY1305,"
++    "ECDHE-RSA-CHACHA20-POLY1305,"
++    "ECDHE-RSA-AES128-SHA,"
++    "ECDHE-RSA-AES256-SHA,"
++    "AES128-GCM-SHA256,"
++    "AES256-GCM-SHA384,"
++    "AES128-SHA,"
++    "AES256-SHA",
++    .npn = false,
++    .alpn = true,
++    .alps = true,
++    .tls_permute_extensions = true,
++    .tls_session_ticket = true,
++    .cert_compression = "brotli",
++    .http_headers = {
++      "sec-ch-ua: \"Not_A Brand\";v=\"8\", \"Chromium\";v=\"120\", \"Google Chrome\";v=\"120\"",
++      "sec-ch-ua-mobile: ?0",
++      "sec-ch-ua-platform: \"macOS\"",
++      "Upgrade-Insecure-Requests: 1",
++      "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
++      "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
++      "Sec-Fetch-Site: none",
++      "Sec-Fetch-Mode: navigate",
++      "Sec-Fetch-User: ?1",
++      "Sec-Fetch-Dest: document",
++      "Accept-Encoding: gzip, deflate, br",
++      "Accept-Language: en-US,en;q=0.9"
++    },
++    .http2_settings = "1:65536;2:0;4:6291456;6:262144",
++    .http2_window_update = 15663105,
++    .http2_stream_weight = 256,
++    .http2_stream_exclusive = 1,
++    .ech = "grease",
++    .tls_extension_order = NULL,
++    .tls_use_new_alps_codepoint = false,
++    .tls_signed_cert_timestamps = true,
++    .tls_grease = true
++  },
++  {
++    .target = "chrome123",
++    .alias = "chrome123",
++    .httpversion = CURL_HTTP_VERSION_2_0,
++    .ssl_version = CURL_SSLVERSION_TLSv1_2 | CURL_SSLVERSION_MAX_DEFAULT,
++    .ciphers =
++    "TLS_AES_128_GCM_SHA256,"
++    "TLS_AES_256_GCM_SHA384,"
++    "TLS_CHACHA20_POLY1305_SHA256,"
++    "ECDHE-ECDSA-AES128-GCM-SHA256,"
++    "ECDHE-RSA-AES128-GCM-SHA256,"
++    "ECDHE-ECDSA-AES256-GCM-SHA384,"
++    "ECDHE-RSA-AES256-GCM-SHA384,"
++    "ECDHE-ECDSA-CHACHA20-POLY1305,"
++    "ECDHE-RSA-CHACHA20-POLY1305,"
++    "ECDHE-RSA-AES128-SHA,"
++    "ECDHE-RSA-AES256-SHA,"
++    "AES128-GCM-SHA256,"
++    "AES256-GCM-SHA384,"
++    "AES128-SHA,"
++    "AES256-SHA",
++    .npn = false,
++    .alpn = true,
++    .alps = true,
++    .tls_permute_extensions = true,
++    .tls_session_ticket = true,
++    .cert_compression = "brotli",
++    .http_headers = {
++      "sec-ch-ua: \"Google Chrome\";v=\"123\", \"Not:A-Brand\";v=\"8\", \"Chromium\";v=\"123\"",
++      "sec-ch-ua-mobile: ?0",
++      "sec-ch-ua-platform: \"macOS\"",
++      "Upgrade-Insecure-Requests: 1",
++      "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36",
++      "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
++      "Sec-Fetch-Site: none",
++      "Sec-Fetch-Mode: navigate",
++      "Sec-Fetch-User: ?1",
++      "Sec-Fetch-Dest: document",
++      "Accept-Encoding: gzip, deflate, br, zstd",
++      "Accept-Language: en-US,en;q=0.9"
++    },
++    .http2_settings = "1:65536;2:0;4:6291456;6:262144",
++    .http2_window_update = 15663105,
++    .http2_stream_weight = 256,
++    .http2_stream_exclusive = 1,
++    .ech = "grease",
++    .tls_extension_order = NULL,
++    .tls_use_new_alps_codepoint = false,
++    .tls_signed_cert_timestamps = true,
++    .tls_grease = true
++  },
++  {
++    .target = "chrome124",
++    .alias = "chrome124",
++    .httpversion = CURL_HTTP_VERSION_2_0,
++    .ssl_version = CURL_SSLVERSION_TLSv1_2 | CURL_SSLVERSION_MAX_DEFAULT,
++    .ciphers =
++    "TLS_AES_128_GCM_SHA256,"
++    "TLS_AES_256_GCM_SHA384,"
++    "TLS_CHACHA20_POLY1305_SHA256,"
++    "ECDHE-ECDSA-AES128-GCM-SHA256,"
++    "ECDHE-RSA-AES128-GCM-SHA256,"
++    "ECDHE-ECDSA-AES256-GCM-SHA384,"
++    "ECDHE-RSA-AES256-GCM-SHA384,"
++    "ECDHE-ECDSA-CHACHA20-POLY1305,"
++    "ECDHE-RSA-CHACHA20-POLY1305,"
++    "ECDHE-RSA-AES128-SHA,"
++    "ECDHE-RSA-AES256-SHA,"
++    "AES128-GCM-SHA256,"
++    "AES256-GCM-SHA384,"
++    "AES128-SHA,"
++    "AES256-SHA",
++    .curves = "X25519Kyber768Draft00:X25519:P-256:P-384",
++    .npn = false,
++    .alpn = true,
++    .alps = true,
++    .tls_permute_extensions = true,
++    .tls_session_ticket = true,
++    .cert_compression = "brotli",
++    .http_headers = {
++      "sec-ch-ua: \"Chromium\";v=\"124\", \"Google Chrome\";v=\"124\", \"Not-A.Brand\";v=\"99\"",
++      "sec-ch-ua-mobile: ?0",
++      "sec-ch-ua-platform: \"macOS\"",
++      "Upgrade-Insecure-Requests: 1",
++      "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
++      "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
++      "Sec-Fetch-Site: none",
++      "Sec-Fetch-Mode: navigate",
++      "Sec-Fetch-User: ?1",
++      "Sec-Fetch-Dest: document",
++      "Accept-Encoding: gzip, deflate, br, zstd",
++      "Accept-Language: en-US,en;q=0.9",
++      "Priority: u=0, i"
++    },
++    .http2_settings = "1:65536;2:0;4:6291456;6:262144",
++    .http2_window_update = 15663105,
++    .http2_stream_weight = 256,
++    .http2_stream_exclusive = 1,
++    .ech = "grease",
++    .tls_extension_order = NULL,
++    .tls_use_new_alps_codepoint = false,
++    .tls_signed_cert_timestamps = true,
++    .tls_grease = true
++  },
++  {
++    .target = "chrome131",
++    .alias = "chrome131",
++    .httpversion = CURL_HTTP_VERSION_2_0,
++    .ssl_version = CURL_SSLVERSION_TLSv1_2 | CURL_SSLVERSION_MAX_DEFAULT,
++    .ciphers =
++    "TLS_AES_128_GCM_SHA256,"
++    "TLS_AES_256_GCM_SHA384,"
++    "TLS_CHACHA20_POLY1305_SHA256,"
++    "ECDHE-ECDSA-AES128-GCM-SHA256,"
++    "ECDHE-RSA-AES128-GCM-SHA256,"
++    "ECDHE-ECDSA-AES256-GCM-SHA384,"
++    "ECDHE-RSA-AES256-GCM-SHA384,"
++    "ECDHE-ECDSA-CHACHA20-POLY1305,"
++    "ECDHE-RSA-CHACHA20-POLY1305,"
++    "ECDHE-RSA-AES128-SHA,"
++    "ECDHE-RSA-AES256-SHA,"
++    "AES128-GCM-SHA256,"
++    "AES256-GCM-SHA384,"
++    "AES128-SHA,"
++    "AES256-SHA",
++    .curves = "X25519MLKEM768:X25519:P-256:P-384",
++    .npn = false,
++    .alpn = true,
++    .alps = true,
++    .tls_permute_extensions = true,
++    .tls_session_ticket = true,
++    .cert_compression = "brotli",
++    .http_headers = {
++      "sec-ch-ua: \"Google Chrome\";v=\"131\", \"Chromium\";v=\"131\", \"Not_A Brand\";v=\"24\"",
++      "sec-ch-ua-mobile: ?0",
++      "sec-ch-ua-platform: \"macOS\"",
++      "Upgrade-Insecure-Requests: 1",
++      "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
++      "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
++      "Sec-Fetch-Site: none",
++      "Sec-Fetch-Mode: navigate",
++      "Sec-Fetch-User: ?1",
++      "Sec-Fetch-Dest: document",
++      "Accept-Encoding: gzip, deflate, br, zstd",
++      "Accept-Language: en-US,en;q=0.9",
++      "Priority: u=0, i"
++    },
++    .http2_settings = "1:65536;2:0;4:6291456;6:262144",
++    .http2_window_update = 15663105,
++    .http2_stream_weight = 256,
++    .http2_stream_exclusive = 1,
++    .ech = "grease",
++    .tls_extension_order = NULL,
++    .tls_use_new_alps_codepoint = false,
++    .tls_signed_cert_timestamps = true,
++    .tls_grease = true
++  },
++  {
++    .target = "chrome131_android",
++    .alias = "chrome131_android",
++    .httpversion = CURL_HTTP_VERSION_2_0,
++    .ssl_version = CURL_SSLVERSION_TLSv1_2 | CURL_SSLVERSION_MAX_DEFAULT,
++    .ciphers =
++    "TLS_AES_128_GCM_SHA256,"
++    "TLS_AES_256_GCM_SHA384,"
++    "TLS_CHACHA20_POLY1305_SHA256,"
++    "ECDHE-ECDSA-AES128-GCM-SHA256,"
++    "ECDHE-RSA-AES128-GCM-SHA256,"
++    "ECDHE-ECDSA-AES256-GCM-SHA384,"
++    "ECDHE-RSA-AES256-GCM-SHA384,"
++    "ECDHE-ECDSA-CHACHA20-POLY1305,"
++    "ECDHE-RSA-CHACHA20-POLY1305,"
++    "ECDHE-RSA-AES128-SHA,"
++    "ECDHE-RSA-AES256-SHA,"
++    "AES128-GCM-SHA256,"
++    "AES256-GCM-SHA384,"
++    "AES128-SHA,"
++    "AES256-SHA",
++    .curves = "X25519:P-256:P-384",
++    .npn = false,
++    .alpn = true,
++    .alps = true,
++    .tls_permute_extensions = true,
++    .tls_session_ticket = true,
++    .cert_compression = "brotli",
++    .http_headers = {
++      "sec-ch-ua: \"Google Chrome\";v=\"131\", \"Chromium\";v=\"131\", \"Not_A Brand\";v=\"24\"",
++      "sec-ch-ua-mobile: ?0",
++      "sec-ch-ua-platform: \"Android\"",
++      "Upgrade-Insecure-Requests: 1",
++      "User-Agent: Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Mobile Safari/537.36",
++      "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
++      "Sec-Fetch-Site: none",
++      "Sec-Fetch-Mode: navigate",
++      "Sec-Fetch-User: ?1",
++      "Sec-Fetch-Dest: document",
++      "Accept-Encoding: gzip, deflate, br, zstd",
++      "Accept-Language: en-US,en;q=0.9",
++      "Priority: u=0, i"
++    },
++    .http2_settings = "1:65536;2:0;4:6291456;6:262144",
++    .http2_window_update = 15663105,
++    .http2_stream_weight = 256,
++    .http2_stream_exclusive = 1,
++    .ech = "grease",
++    .tls_extension_order = NULL,
++    .tls_use_new_alps_codepoint = false,
++    .tls_signed_cert_timestamps = true,
++    .tls_grease = true
++  },
++  {
++    .target = "chrome133a",
++    .alias = "chrome133a",
++    .httpversion = CURL_HTTP_VERSION_2_0,
++    .ssl_version = CURL_SSLVERSION_TLSv1_2 | CURL_SSLVERSION_MAX_DEFAULT,
++    .ciphers =
++    "TLS_AES_128_GCM_SHA256,"
++    "TLS_AES_256_GCM_SHA384,"
++    "TLS_CHACHA20_POLY1305_SHA256,"
++    "ECDHE-ECDSA-AES128-GCM-SHA256,"
++    "ECDHE-RSA-AES128-GCM-SHA256,"
++    "ECDHE-ECDSA-AES256-GCM-SHA384,"
++    "ECDHE-RSA-AES256-GCM-SHA384,"
++    "ECDHE-ECDSA-CHACHA20-POLY1305,"
++    "ECDHE-RSA-CHACHA20-POLY1305,"
++    "ECDHE-RSA-AES128-SHA,"
++    "ECDHE-RSA-AES256-SHA,"
++    "AES128-GCM-SHA256,"
++    "AES256-GCM-SHA384,"
++    "AES128-SHA,"
++    "AES256-SHA",
++    .curves = "X25519MLKEM768:X25519:P-256:P-384",
++    .npn = false,
++    .alpn = true,
++    .alps = true,
++    .tls_permute_extensions = true,
++    .tls_session_ticket = true,
++    .cert_compression = "brotli",
++    .http_headers = {
++      "sec-ch-ua: \"Not(A:Brand\";v=\"99\", \"Google Chrome\";v=\"133\", \"Chromium\";v=\"133\"",
++      "sec-ch-ua-mobile: ?0",
++      "sec-ch-ua-platform: \"macOS\"",
++      "Upgrade-Insecure-Requests: 1",
++      "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36",
++      "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
++      "Sec-Fetch-Site: none",
++      "Sec-Fetch-Mode: navigate",
++      "Sec-Fetch-User: ?1",
++      "Sec-Fetch-Dest: document",
++      "Accept-Encoding: gzip, deflate, br, zstd",
++      "Accept-Language: en-US,en;q=0.9",
++      "Priority: u=0, i"
++    },
++    .http2_settings = "1:65536;2:0;4:6291456;6:262144",
++    .http2_window_update = 15663105,
++    .http2_stream_weight = 256,
++    .http2_stream_exclusive = 1,
++    .ech = "grease",
++    .tls_extension_order = NULL,
++    .tls_use_new_alps_codepoint = true,
++    .tls_signed_cert_timestamps = true,
++    .tls_grease = true
++  },
++  {
++    .target = "chrome136",
++    .alias = "chrome136",
++    .httpversion = CURL_HTTP_VERSION_2_0,
++    .ssl_version = CURL_SSLVERSION_TLSv1_2 | CURL_SSLVERSION_MAX_DEFAULT,
++    .ciphers =
++    "TLS_AES_128_GCM_SHA256,"
++    "TLS_AES_256_GCM_SHA384,"
++    "TLS_CHACHA20_POLY1305_SHA256,"
++    "ECDHE-ECDSA-AES128-GCM-SHA256,"
++    "ECDHE-RSA-AES128-GCM-SHA256,"
++    "ECDHE-ECDSA-AES256-GCM-SHA384,"
++    "ECDHE-RSA-AES256-GCM-SHA384,"
++    "ECDHE-ECDSA-CHACHA20-POLY1305,"
++    "ECDHE-RSA-CHACHA20-POLY1305,"
++    "ECDHE-RSA-AES128-SHA,"
++    "ECDHE-RSA-AES256-SHA,"
++    "AES128-GCM-SHA256,"
++    "AES256-GCM-SHA384,"
++    "AES128-SHA,"
++    "AES256-SHA",
++    .curves = "X25519MLKEM768:X25519:P-256:P-384",
++    .npn = false,
++    .alpn = true,
++    .alps = true,
++    .tls_permute_extensions = true,
++    .tls_session_ticket = true,
++    .cert_compression = "brotli",
++    .http_headers = {
++      "sec-ch-ua: \"Chromium\";v=\"136\", \"Google Chrome\";v=\"136\", \"Not.A/Brand\";v=\"99\"",
++      "sec-ch-ua-mobile: ?0",
++      "sec-ch-ua-platform: \"macOS\"",
++      "Upgrade-Insecure-Requests: 1",
++      "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36",
++      "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
++      "Sec-Fetch-Site: none",
++      "Sec-Fetch-Mode: navigate",
++      "Sec-Fetch-User: ?1",
++      "Sec-Fetch-Dest: document",
++      "Accept-Encoding: gzip, deflate, br, zstd",
++      "Accept-Language: en-US,en;q=0.9",
++      "Priority: u=0, i"
++    },
++    .http2_settings = "1:65536;2:0;4:6291456;6:262144",
++    .http2_window_update = 15663105,
++    .http2_stream_weight = 256,
++    .http2_stream_exclusive = 1,
++    .ech = "grease",
++    .tls_extension_order = NULL,
++    .tls_use_new_alps_codepoint = true,
++    .tls_signed_cert_timestamps = true,
++    .tls_grease = true
++  },
++  {
++    .target = "chrome99",
++    .alias = "chrome99",
++    .httpversion = CURL_HTTP_VERSION_2_0,
++    .ssl_version = CURL_SSLVERSION_TLSv1_2 | CURL_SSLVERSION_MAX_DEFAULT,
++    .ciphers =
++    "TLS_AES_128_GCM_SHA256,"
++    "TLS_AES_256_GCM_SHA384,"
++    "TLS_CHACHA20_POLY1305_SHA256,"
++    "ECDHE-ECDSA-AES128-GCM-SHA256,"
++    "ECDHE-RSA-AES128-GCM-SHA256,"
++    "ECDHE-ECDSA-AES256-GCM-SHA384,"
++    "ECDHE-RSA-AES256-GCM-SHA384,"
++    "ECDHE-ECDSA-CHACHA20-POLY1305,"
++    "ECDHE-RSA-CHACHA20-POLY1305,"
++    "ECDHE-RSA-AES128-SHA,"
++    "ECDHE-RSA-AES256-SHA,"
++    "AES128-GCM-SHA256,"
++    "AES256-GCM-SHA384,"
++    "AES128-SHA,"
++    "AES256-SHA",
++    .npn = false,
++    .alpn = true,
++    .alps = true,
++    .tls_session_ticket = true,
++    .cert_compression = "brotli",
++    .http_headers = {
++      "sec-ch-ua: \" Not A;Brand\";v=\"99\", \"Chromium\";v=\"99\", \"Google Chrome\";v=\"99\"",
++      "sec-ch-ua-mobile: ?0",
++      "sec-ch-ua-platform: \"Windows\"",
++      "Upgrade-Insecure-Requests: 1",
++      "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.51 Safari/537.36",
++      "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
++      "Sec-Fetch-Site: none",
++      "Sec-Fetch-Mode: navigate",
++      "Sec-Fetch-User: ?1",
++      "Sec-Fetch-Dest: document",
++      "Accept-Encoding: gzip, deflate, br",
++      "Accept-Language: en-US,en;q=0.9"
++    },
++    .http2_settings = "1:65536;3:1000;4:6291456;6:262144",
++    .http2_window_update = 15663105,
++    .http2_stream_weight = 256,
++    .http2_stream_exclusive = 1,
++    .tls_extension_order = NULL,
++    .tls_use_new_alps_codepoint = false,
++    .tls_signed_cert_timestamps = true,
++    .tls_grease = true
++  },
++  {
++    .target = "chrome99_android",
++    .alias = "chrome99_android",
++    .httpversion = CURL_HTTP_VERSION_2_0,
++    .ssl_version = CURL_SSLVERSION_TLSv1_2 | CURL_SSLVERSION_MAX_DEFAULT,
++    .ciphers =
++    "TLS_AES_128_GCM_SHA256,"
++    "TLS_AES_256_GCM_SHA384,"
++    "TLS_CHACHA20_POLY1305_SHA256,"
++    "ECDHE-ECDSA-AES128-GCM-SHA256,"
++    "ECDHE-RSA-AES128-GCM-SHA256,"
++    "ECDHE-ECDSA-AES256-GCM-SHA384,"
++    "ECDHE-RSA-AES256-GCM-SHA384,"
++    "ECDHE-ECDSA-CHACHA20-POLY1305,"
++    "ECDHE-RSA-CHACHA20-POLY1305,"
++    "ECDHE-RSA-AES128-SHA,"
++    "ECDHE-RSA-AES256-SHA,"
++    "AES128-GCM-SHA256,"
++    "AES256-GCM-SHA384,"
++    "AES128-SHA,"
++    "AES256-SHA",
++    .npn = false,
++    .alpn = true,
++    .alps = true,
++    .tls_session_ticket = true,
++    .cert_compression = "brotli",
++    .http_headers = {
++      "sec-ch-ua: \" Not A;Brand\";v=\"99\", \"Chromium\";v=\"99\", \"Google Chrome\";v=\"99\"",
++      "sec-ch-ua-mobile: ?1",
++      "sec-ch-ua-platform: \"Android\"",
++      "Upgrade-Insecure-Requests: 1",
++      "User-Agent: Mozilla/5.0 (Linux; Android 12; Pixel 6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.58 Mobile Safari/537.36",
++      "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
++      "Sec-Fetch-Site: none",
++      "Sec-Fetch-Mode: navigate",
++      "Sec-Fetch-User: ?1",
++      "Sec-Fetch-Dest: document",
++      "Accept-Encoding: gzip, deflate, br",
++      "Accept-Language: en-US,en;q=0.9"
++    },
++    .http2_settings = "1:65536;3:1000;4:6291456;6:262144",
++    .http2_window_update = 15663105,
++    .http2_stream_weight = 256,
++    .http2_stream_exclusive = 1,
++    .tls_extension_order = NULL,
++    .tls_use_new_alps_codepoint = false,
++    .tls_signed_cert_timestamps = true,
++    .tls_grease = true
++  },
++  {
++    .target = "edge101",
++    .alias = "edge101",
++    .httpversion = CURL_HTTP_VERSION_2_0,
++    .ssl_version = CURL_SSLVERSION_TLSv1_2 | CURL_SSLVERSION_MAX_DEFAULT,
++    .ciphers =
++    "TLS_AES_128_GCM_SHA256,"
++    "TLS_AES_256_GCM_SHA384,"
++    "TLS_CHACHA20_POLY1305_SHA256,"
++    "ECDHE-ECDSA-AES128-GCM-SHA256,"
++    "ECDHE-RSA-AES128-GCM-SHA256,"
++    "ECDHE-ECDSA-AES256-GCM-SHA384,"
++    "ECDHE-RSA-AES256-GCM-SHA384,"
++    "ECDHE-ECDSA-CHACHA20-POLY1305,"
++    "ECDHE-RSA-CHACHA20-POLY1305,"
++    "ECDHE-RSA-AES128-SHA,"
++    "ECDHE-RSA-AES256-SHA,"
++    "AES128-GCM-SHA256,"
++    "AES256-GCM-SHA384,"
++    "AES128-SHA,"
++    "AES256-SHA",
++    .npn = false,
++    .alpn = true,
++    .alps = true,
++    .tls_session_ticket = true,
++    .cert_compression = "brotli",
++    .http_headers = {
++      "sec-ch-ua: \" Not A;Brand\";v=\"99\", \"Chromium\";v=\"101\", \"Microsoft Edge\";v=\"101\"",
++      "sec-ch-ua-mobile: ?0",
++      "sec-ch-ua-platform: \"Windows\"",
++      "Upgrade-Insecure-Requests: 1",
++      "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.64 Safari/537.36 Edg/101.0.1210.47",
++      "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
++      "Sec-Fetch-Site: none",
++      "Sec-Fetch-Mode: navigate",
++      "Sec-Fetch-User: ?1",
++      "Sec-Fetch-Dest: document",
++      "Accept-Encoding: gzip, deflate, br",
++      "Accept-Language: en-US,en;q=0.9"
++    },
++    .http2_settings = "1:65536;3:1000;4:6291456;6:262144",
++    .http2_window_update = 15663105,
++    .http2_stream_weight = 256,
++    .http2_stream_exclusive = 1,
++    .tls_extension_order = NULL,
++    .tls_use_new_alps_codepoint = false,
++    .tls_signed_cert_timestamps = true,
++    .tls_grease = true
++  },
++  {
++    .target = "edge99",
++    .alias = "edge99",
++    .httpversion = CURL_HTTP_VERSION_2_0,
++    .ssl_version = CURL_SSLVERSION_TLSv1_2 | CURL_SSLVERSION_MAX_DEFAULT,
++    .ciphers =
++    "TLS_AES_128_GCM_SHA256,"
++    "TLS_AES_256_GCM_SHA384,"
++    "TLS_CHACHA20_POLY1305_SHA256,"
++    "ECDHE-ECDSA-AES128-GCM-SHA256,"
++    "ECDHE-RSA-AES128-GCM-SHA256,"
++    "ECDHE-ECDSA-AES256-GCM-SHA384,"
++    "ECDHE-RSA-AES256-GCM-SHA384,"
++    "ECDHE-ECDSA-CHACHA20-POLY1305,"
++    "ECDHE-RSA-CHACHA20-POLY1305,"
++    "ECDHE-RSA-AES128-SHA,"
++    "ECDHE-RSA-AES256-SHA,"
++    "AES128-GCM-SHA256,"
++    "AES256-GCM-SHA384,"
++    "AES128-SHA,"
++    "AES256-SHA",
++    .npn = false,
++    .alpn = true,
++    .alps = true,
++    .tls_session_ticket = true,
++    .cert_compression = "brotli",
++    .http_headers = {
++      "sec-ch-ua: \" Not A;Brand\";v=\"99\", \"Chromium\";v=\"99\", \"Microsoft Edge\";v=\"99\"",
++      "sec-ch-ua-mobile: ?0",
++      "sec-ch-ua-platform: \"Windows\"",
++      "Upgrade-Insecure-Requests: 1",
++      "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.51 Safari/537.36 Edg/99.0.1150.30",
++      "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
++      "Sec-Fetch-Site: none",
++      "Sec-Fetch-Mode: navigate",
++      "Sec-Fetch-User: ?1",
++      "Sec-Fetch-Dest: document",
++      "Accept-Encoding: gzip, deflate, br",
++      "Accept-Language: en-US,en;q=0.9"
++    },
++    .http2_settings = "1:65536;3:1000;4:6291456;6:262144",
++    .http2_window_update = 15663105,
++    .http2_stream_weight = 256,
++    .http2_stream_exclusive = 1,
++    .tls_extension_order = NULL,
++    .tls_use_new_alps_codepoint = false,
++    .tls_signed_cert_timestamps = true,
++    .tls_grease = true
++  },
++  {
++    .target = "firefox133",
++    .httpversion = CURL_HTTP_VERSION_2_0,
++    .ssl_version = CURL_SSLVERSION_TLSv1_2 | CURL_SSLVERSION_MAX_DEFAULT,
++    .ciphers =
++    "TLS_AES_128_GCM_SHA256,"
++    "TLS_CHACHA20_POLY1305_SHA256,"
++    "TLS_AES_256_GCM_SHA384,"
++    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,"
++    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,"
++    "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,"
++    "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,"
++    "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,"
++    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,"
++    "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,"
++    "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,"
++    "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,"
++    "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,"
++    "TLS_RSA_WITH_AES_128_GCM_SHA256,"
++    "TLS_RSA_WITH_AES_256_GCM_SHA384,"
++    "TLS_RSA_WITH_AES_128_CBC_SHA,"
++    "TLS_RSA_WITH_AES_256_CBC_SHA",
++    .http_headers = {
++      "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:133.0) Gecko/20100101 Firefox/133.0",
++      "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
++      "Accept-Language: en-US,en;q=0.5",
++      "Accept-Encoding: gzip, deflate, br, zstd",
++      "Upgrade-Insecure-Requests: 1",
++      "Sec-Fetch-Dest: document",
++      "Sec-Fetch-Mode: navigate",
++      "Sec-Fetch-Site: none",
++      "Sec-Fetch-User: ?1",
++      "Priority: u=0, i",
++      "Te: trailers"
++    },
++    .curves = "X25519MLKEM768:X25519:P-256:P-384:P-521:ffdhe2048:ffdhe3072",
++    .sig_hash_algs =
++    "ecdsa_secp256r1_sha256,"
++    "ecdsa_secp384r1_sha384,"
++    "ecdsa_secp521r1_sha512,"
++    "rsa_pss_rsae_sha256,"
++    "rsa_pss_rsae_sha384,"
++    "rsa_pss_rsae_sha512,"
++    "rsa_pkcs1_sha256,"
++    "rsa_pkcs1_sha384,"
++    "rsa_pkcs1_sha512,"
++    "ecdsa_sha1,"
++    "rsa_pkcs1_sha1",
++    .alpn = true,
++    .http2_settings = "1:65536;2:0;4:131072;5:16384",
++    .http2_window_update = 12517377,
++    .http2_pseudo_headers_order = "mpas",
++    .http2_stream_exclusive = 0,
++    .cert_compression = "zlib,brotli,zstd",
++    .ech = "grease",
++    .tls_session_ticket = true,
++    .tls_extension_order = "0-23-65281-10-11-35-16-5-34-51-43-13-45-28-27-65037",
++    .tls_delegated_credentials = "ecdsa_secp256r1_sha256:ecdsa_secp384r1_sha384:ecdsa_secp521r1_sha512:ecdsa_sha1",
++    .tls_record_size_limit = 4001,
++    .tls_grease = false,
++    .tls_signed_cert_timestamps = false,
++    .tls_key_shares_limit = 3,
++    .use_firefox_tls13_ciphers = true
++  },
++  {
++    .target = "firefox135",
++    .alias = "firefox135",
++    .httpversion = CURL_HTTP_VERSION_2_0,
++    .ssl_version = CURL_SSLVERSION_TLSv1_2 | CURL_SSLVERSION_MAX_DEFAULT,
++    .ciphers =
++    "TLS_AES_128_GCM_SHA256,"
++    "TLS_CHACHA20_POLY1305_SHA256,"
++    "TLS_AES_256_GCM_SHA384,"
++    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,"
++    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,"
++    "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,"
++    "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,"
++    "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,"
++    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,"
++    "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,"
++    "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,"
++    "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,"
++    "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,"
++    "TLS_RSA_WITH_AES_128_GCM_SHA256,"
++    "TLS_RSA_WITH_AES_256_GCM_SHA384,"
++    "TLS_RSA_WITH_AES_128_CBC_SHA,"
++    "TLS_RSA_WITH_AES_256_CBC_SHA",
++    .http_headers = {
++      "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:135.0) Gecko/20100101 Firefox/135.0",
++      "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
++      "Accept-Language: en-US,en;q=0.5",
++      "Accept-Encoding: gzip, deflate, br, zstd",
++      "Upgrade-Insecure-Requests: 1",
++      "Sec-Fetch-Dest: document",
++      "Sec-Fetch-Mode: navigate",
++      "Sec-Fetch-Site: none",
++      "Sec-Fetch-User: ?1",
++      "Priority: u=0, i",
++      "Te: trailers"
++    },
++    .curves = "X25519MLKEM768:X25519:P-256:P-384:P-521:ffdhe2048:ffdhe3072",
++    .sig_hash_algs =
++    "ecdsa_secp256r1_sha256,"
++    "ecdsa_secp384r1_sha384,"
++    "ecdsa_secp521r1_sha512,"
++    "rsa_pss_rsae_sha256,"
++    "rsa_pss_rsae_sha384,"
++    "rsa_pss_rsae_sha512,"
++    "rsa_pkcs1_sha256,"
++    "rsa_pkcs1_sha384,"
++    "rsa_pkcs1_sha512,"
++    "ecdsa_sha1,"
++    "rsa_pkcs1_sha1",
++    .alpn = true,
++    .http2_settings = "1:65536;2:0;4:131072;5:16384",
++    .http2_window_update = 12517377,
++    .http2_pseudo_headers_order = "mpas",
++    .http2_stream_exclusive = 0,
++    .cert_compression = "zlib,brotli,zstd",
++    .ech = "grease",
++    .tls_session_ticket = true,
++    .tls_extension_order = "0-23-65281-10-11-35-16-5-34-18-51-43-13-45-28-27-65037",
++    .tls_delegated_credentials = "ecdsa_secp256r1_sha256:ecdsa_secp384r1_sha384:ecdsa_secp521r1_sha512:ecdsa_sha1",
++    .tls_record_size_limit = 4001,
++    .tls_grease = false,
++    .tls_signed_cert_timestamps = true,
++    .tls_key_shares_limit = 3,
++    .use_firefox_tls13_ciphers = true
++  },
++  {
++    .target = "okhttp4_android",
++    .alias = "okhttp4", /* not working */
++    .httpversion = CURL_HTTP_VERSION_2_0,
++    .ssl_version = CURL_SSLVERSION_TLSv1_0 | CURL_SSLVERSION_MAX_DEFAULT,
++    .ciphers =
++    "TLS_AES_128_GCM_SHA256,"
++    "TLS_AES_256_GCM_SHA384,"
++    "TLS_CHACHA20_POLY1305_SHA256,"
++    "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,"
++    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,"
++    "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,"
++    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,"
++    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,"
++    "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,"
++    "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,"
++    "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,"
++    "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,"
++    "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,"
++    "TLS_RSA_WITH_AES_256_GCM_SHA384,"
++    "TLS_RSA_WITH_AES_128_GCM_SHA256,"
++    "TLS_RSA_WITH_AES_256_CBC_SHA,"
++    "TLS_RSA_WITH_AES_128_CBC_SHA,"
++    "TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA,"
++    "TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,"
++    "TLS_RSA_WITH_3DES_EDE_CBC_SHA",
++    .curves = "X25519:P-256:P-384:P-521",
++    .sig_hash_algs =
++    "ecdsa_secp256r1_sha256,"
++    "rsa_pss_rsae_sha256,"
++    "rsa_pkcs1_sha256,"
++    "ecdsa_secp384r1_sha384,"
++    "ecdsa_sha1,"
++    "rsa_pss_rsae_sha384,"
++    "rsa_pss_rsae_sha384,"
++    "rsa_pkcs1_sha384,"
++    "rsa_pss_rsae_sha512,"
++    "rsa_pkcs1_sha512,"
++    "rsa_pkcs1_sha1",
++    .npn = false,
++    .alpn = true,
++    .alps = false,
++    .tls_session_ticket = false,
++    .cert_compression = "zlib",
++    .http_headers = {
++      "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
++      "Sec-Fetch-Site: none",
++      "Accept-Encoding: gzip, deflate, br",
++      "Sec-Fetch-Mode: navigate",
++      "user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15",
++      "Accept-Language: en-US,en;q=0.9",
++      "Sec-Fetch-Dest: document"
++    },
++    .http2_settings = "2:0;4:4194304;3:100",
++    .http2_window_update = 10485760,
++    .http2_pseudo_headers_order = "mspa",
++    .http2_stream_weight = 255,
++    .tls_extension_order = NULL,
++    .tls_use_new_alps_codepoint = false,
++    .tls_signed_cert_timestamps = true,
++    .tls_grease = true
++  },
++  {
++    .target = "safari153",
++    .alias = "safari15_3",
++    .httpversion = CURL_HTTP_VERSION_2_0,
++    .ssl_version = CURL_SSLVERSION_TLSv1_0 | CURL_SSLVERSION_MAX_DEFAULT,
++    .ciphers =
++    "TLS_AES_128_GCM_SHA256,"
++    "TLS_AES_256_GCM_SHA384,"
++    "TLS_CHACHA20_POLY1305_SHA256,"
++    "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,"
++    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,"
++    "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,"
++    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,"
++    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,"
++    "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,"
++    "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384,"
++    "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,"
++    "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,"
++    "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,"
++    "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,"
++    "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,"
++    "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,"
++    "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,"
++    "TLS_RSA_WITH_AES_256_GCM_SHA384,"
++    "TLS_RSA_WITH_AES_128_GCM_SHA256,"
++    "TLS_RSA_WITH_AES_256_CBC_SHA256,"
++    "TLS_RSA_WITH_AES_128_CBC_SHA256,"
++    "TLS_RSA_WITH_AES_256_CBC_SHA,"
++    "TLS_RSA_WITH_AES_128_CBC_SHA,"
++    "TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA,"
++    "TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,"
++    "TLS_RSA_WITH_3DES_EDE_CBC_SHA,",
++    .curves = "X25519:P-256:P-384:P-521",
++    .sig_hash_algs =
++    "ecdsa_secp256r1_sha256,"
++    "rsa_pss_rsae_sha256,"
++    "rsa_pkcs1_sha256,"
++    "ecdsa_secp384r1_sha384,"
++    "ecdsa_sha1,"
++    "rsa_pss_rsae_sha384,"
++    "rsa_pss_rsae_sha384,"
++    "rsa_pkcs1_sha384,"
++    "rsa_pss_rsae_sha512,"
++    "rsa_pkcs1_sha512,"
++    "rsa_pkcs1_sha1",
++    .npn = false,
++    .alpn = true,
++    .alps = false,
++    .tls_session_ticket = false,
++    .http_headers = {
++      "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.3 Safari/605.1.15",
++      "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
++      "Accept-Language: en-us",
++      "Accept-Encoding: gzip, deflate, br"
++    },
++    .http2_settings = "4:4194304;3:100",
++    .http2_window_update = 10485760,
++    .http2_pseudo_headers_order = "mspa",
++    .http2_stream_weight = 255,
++    .http2_stream_exclusive = 0,
++    .tls_extension_order = NULL,
++    .tls_use_new_alps_codepoint = false,
++    .tls_signed_cert_timestamps = true,
++    .tls_grease = true
++  },
++  {
++    .target = "safari155",
++    .alias = "safari15_5",
++    .httpversion = CURL_HTTP_VERSION_2_0,
++    .ssl_version = CURL_SSLVERSION_TLSv1_0 | CURL_SSLVERSION_MAX_DEFAULT,
++    .ciphers =
++    "TLS_AES_128_GCM_SHA256,"
++    "TLS_AES_256_GCM_SHA384,"
++    "TLS_CHACHA20_POLY1305_SHA256,"
++    "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,"
++    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,"
++    "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,"
++    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,"
++    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,"
++    "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,"
++    "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,"
++    "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,"
++    "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,"
++    "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,"
++    "TLS_RSA_WITH_AES_256_GCM_SHA384,"
++    "TLS_RSA_WITH_AES_128_GCM_SHA256,"
++    "TLS_RSA_WITH_AES_256_CBC_SHA,"
++    "TLS_RSA_WITH_AES_128_CBC_SHA,"
++    "TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA,"
++    "TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,"
++    "TLS_RSA_WITH_3DES_EDE_CBC_SHA",
++    .curves = "X25519:P-256:P-384:P-521",
++    .sig_hash_algs =
++    "ecdsa_secp256r1_sha256,"
++    "rsa_pss_rsae_sha256,"
++    "rsa_pkcs1_sha256,"
++    "ecdsa_secp384r1_sha384,"
++    "ecdsa_sha1,"
++    "rsa_pss_rsae_sha384,"
++    "rsa_pss_rsae_sha384,"
++    "rsa_pkcs1_sha384,"
++    "rsa_pss_rsae_sha512,"
++    "rsa_pkcs1_sha512,"
++    "rsa_pkcs1_sha1",
++    .npn = false,
++    .alpn = true,
++    .alps = false,
++    .tls_session_ticket = false,
++    .cert_compression = "zlib",
++    .http_headers = {
++      "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.5 Safari/605.1.15",
++      "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
++      "Accept-Language: en-GB,en-US;q=0.9,en;q=0.8",
++      "Accept-Encoding: gzip, deflate, br"
++    },
++    .http2_settings = "4:4194304;3:100",
++    .http2_window_update = 10485760,
++    .http2_pseudo_headers_order = "mspa",
++    .http2_stream_weight = 255,
++    .http2_stream_exclusive = 0,
++    .tls_extension_order = NULL,
++    .tls_use_new_alps_codepoint = false,
++    .tls_signed_cert_timestamps = true,
++    .tls_grease = true
++  },
++  {
++    .target = "safari170",
++    .alias = "safari17_0",
++    .httpversion = CURL_HTTP_VERSION_2_0,
++    .ssl_version = CURL_SSLVERSION_TLSv1_0 | CURL_SSLVERSION_MAX_DEFAULT,
++    .ciphers =
++    "TLS_AES_128_GCM_SHA256,"
++    "TLS_AES_256_GCM_SHA384,"
++    "TLS_CHACHA20_POLY1305_SHA256,"
++    "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,"
++    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,"
++    "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,"
++    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,"
++    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,"
++    "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,"
++    "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,"
++    "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,"
++    "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,"
++    "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,"
++    "TLS_RSA_WITH_AES_256_GCM_SHA384,"
++    "TLS_RSA_WITH_AES_128_GCM_SHA256,"
++    "TLS_RSA_WITH_AES_256_CBC_SHA,"
++    "TLS_RSA_WITH_AES_128_CBC_SHA,"
++    "TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA,"
++    "TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,"
++    "TLS_RSA_WITH_3DES_EDE_CBC_SHA",
++    .curves = "X25519:P-256:P-384:P-521",
++    .sig_hash_algs =
++    "ecdsa_secp256r1_sha256,"
++    "rsa_pss_rsae_sha256,"
++    "rsa_pkcs1_sha256,"
++    "ecdsa_secp384r1_sha384,"
++    "ecdsa_sha1,"
++    "rsa_pss_rsae_sha384,"
++    "rsa_pss_rsae_sha384,"
++    "rsa_pkcs1_sha384,"
++    "rsa_pss_rsae_sha512,"
++    "rsa_pkcs1_sha512,"
++    "rsa_pkcs1_sha1",
++    .npn = false,
++    .alpn = true,
++    .alps = false,
++    .tls_session_ticket = false,
++    .cert_compression = "zlib",
++    .http_headers = {
++      "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
++      "Sec-Fetch-Site: none",
++      "Accept-Encoding: gzip, deflate, br",
++      "Sec-Fetch-Mode: navigate",
++      "user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15",
++      "Accept-Language: en-US,en;q=0.9",
++      "Sec-Fetch-Dest: document"
++    },
++    .http2_settings = "2:0;4:4194304;3:100",
++    .http2_window_update = 10485760,
++    .http2_pseudo_headers_order = "mspa",
++    .http2_stream_weight = 255,
++    .http2_stream_exclusive = 0,
++    .tls_extension_order = NULL,
++    .tls_use_new_alps_codepoint = false,
++    .tls_signed_cert_timestamps = true,
++    .tls_grease = true
++  },
++  {
++    .target = "safari172_ios",
++    .alias = "safari17_2_ios",
++    .httpversion = CURL_HTTP_VERSION_2_0,
++    .ssl_version = CURL_SSLVERSION_TLSv1_0 | CURL_SSLVERSION_MAX_DEFAULT,
++    .ciphers =
++    "TLS_AES_128_GCM_SHA256,"
++    "TLS_AES_256_GCM_SHA384,"
++    "TLS_CHACHA20_POLY1305_SHA256,"
++    "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,"
++    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,"
++    "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,"
++    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,"
++    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,"
++    "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,"
++    "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,"
++    "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,"
++    "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,"
++    "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,"
++    "TLS_RSA_WITH_AES_256_GCM_SHA384,"
++    "TLS_RSA_WITH_AES_128_GCM_SHA256,"
++    "TLS_RSA_WITH_AES_256_CBC_SHA,"
++    "TLS_RSA_WITH_AES_128_CBC_SHA,"
++    "TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA,"
++    "TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,"
++    "TLS_RSA_WITH_3DES_EDE_CBC_SHA",
++    .curves = "X25519:P-256:P-384:P-521",
++    .sig_hash_algs =
++    "ecdsa_secp256r1_sha256,"
++    "rsa_pss_rsae_sha256,"
++    "rsa_pkcs1_sha256,"
++    "ecdsa_secp384r1_sha384,"
++    "ecdsa_sha1,"
++    "rsa_pss_rsae_sha384,"
++    "rsa_pss_rsae_sha384,"
++    "rsa_pkcs1_sha384,"
++    "rsa_pss_rsae_sha512,"
++    "rsa_pkcs1_sha512,"
++    "rsa_pkcs1_sha1",
++    .npn = false,
++    .alpn = true,
++    .alps = false,
++    .tls_session_ticket = false,
++    .cert_compression = "zlib",
++    .http_headers = {
++      "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
++      "Sec-Fetch-Site: none",
++      "Accept-Encoding: gzip, deflate, br",
++      "Sec-Fetch-Mode: navigate",
++      "User-Agent: Mozilla/5.0 (iPhone; CPU iPhone OS 17_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Mobile/15E148 Safari/604.1",
++      "Accept-Language: en-US,en;q=0.9",
++      "Sec-Fetch-Dest: document"
++    },
++    .http2_settings = "2:0;4:2097152;3:100",
++    .http2_window_update = 10485760,
++    .http2_pseudo_headers_order = "mspa",
++    .http2_stream_weight = 255,
++    .http2_stream_exclusive = 0,
++    .tls_extension_order = NULL,
++    .tls_use_new_alps_codepoint = false,
++    .tls_signed_cert_timestamps = true,
++    .tls_grease = true
++  },
++  {
++    .target = "safari180",
++    .alias = "safari18_0",
++    .httpversion = CURL_HTTP_VERSION_2_0,
++    .ssl_version = CURL_SSLVERSION_TLSv1_0 | CURL_SSLVERSION_MAX_DEFAULT,
++    .ciphers =
++    "TLS_AES_128_GCM_SHA256,"
++    "TLS_AES_256_GCM_SHA384,"
++    "TLS_CHACHA20_POLY1305_SHA256,"
++    "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,"
++    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,"
++    "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,"
++    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,"
++    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,"
++    "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,"
++    "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,"
++    "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,"
++    "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,"
++    "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,"
++    "TLS_RSA_WITH_AES_256_GCM_SHA384,"
++    "TLS_RSA_WITH_AES_128_GCM_SHA256,"
++    "TLS_RSA_WITH_AES_256_CBC_SHA,"
++    "TLS_RSA_WITH_AES_128_CBC_SHA,"
++    "TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA,"
++    "TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,"
++    "TLS_RSA_WITH_3DES_EDE_CBC_SHA",
++    .curves = "X25519:P-256:P-384:P-521",
++    .sig_hash_algs =
++    "ecdsa_secp256r1_sha256,"
++    "rsa_pss_rsae_sha256,"
++    "rsa_pkcs1_sha256,"
++    "ecdsa_secp384r1_sha384,"
++    "rsa_pss_rsae_sha384,"
++    "rsa_pss_rsae_sha384,"
++    "rsa_pkcs1_sha384,"
++    "rsa_pss_rsae_sha512,"
++    "rsa_pkcs1_sha512,"
++    "rsa_pkcs1_sha1",
++    .npn = false,
++    .alpn = true,
++    .alps = false,
++    .tls_session_ticket = false,
++    .cert_compression = "zlib",
++    .http_headers = {
++      "sec-fetch-dest: document",
++      "user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Safari/605.1.15",
++      "accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
++      "sec-fetch-site: none",
++      "sec-fetch-mode: navigate",
++      "accept-language: en-US,en;q=0.9",
++      "priority: u=0, i",
++      "accept-encoding: gzip, deflate, br"
++    },
++    .http2_settings = "2:0;3:100;4:2097152;8:1;9:1",
++    .http2_window_update = 10420225,
++    .http2_pseudo_headers_order = "msap",
++    .http2_stream_weight = 256,
++    .http2_stream_exclusive = 0,
++    .tls_extension_order = NULL,
++    .tls_use_new_alps_codepoint = false,
++    .tls_signed_cert_timestamps = true,
++    .tls_grease = true
++  },
++  {
++    .target = "safari180_ios",
++    .alias = "safari18_0_ios",
++    .httpversion = CURL_HTTP_VERSION_2_0,
++    .ssl_version = CURL_SSLVERSION_TLSv1_0 | CURL_SSLVERSION_MAX_DEFAULT,
++    .ciphers =
++    "TLS_AES_128_GCM_SHA256,"
++    "TLS_AES_256_GCM_SHA384,"
++    "TLS_CHACHA20_POLY1305_SHA256,"
++    "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,"
++    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,"
++    "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,"
++    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,"
++    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,"
++    "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,"
++    "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,"
++    "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,"
++    "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,"
++    "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,"
++    "TLS_RSA_WITH_AES_256_GCM_SHA384,"
++    "TLS_RSA_WITH_AES_128_GCM_SHA256,"
++    "TLS_RSA_WITH_AES_256_CBC_SHA,"
++    "TLS_RSA_WITH_AES_128_CBC_SHA,"
++    "TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA,"
++    "TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,"
++    "TLS_RSA_WITH_3DES_EDE_CBC_SHA",
++    .curves = "X25519:P-256:P-384:P-521",
++    .sig_hash_algs =
++    "ecdsa_secp256r1_sha256,"
++    "rsa_pss_rsae_sha256,"
++    "rsa_pkcs1_sha256,"
++    "ecdsa_secp384r1_sha384,"
++    "rsa_pss_rsae_sha384,"
++    "rsa_pss_rsae_sha384,"
++    "rsa_pkcs1_sha384,"
++    "rsa_pss_rsae_sha512,"
++    "rsa_pkcs1_sha512,"
++    "rsa_pkcs1_sha1",
++    .npn = false,
++    .alpn = true,
++    .alps = false,
++    .tls_session_ticket = false,
++    .cert_compression = "zlib",
++    .http_headers = {
++      "sec-fetch-dest: document",
++      "user-agent: Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Mobile/15E148 Safari/604.1",
++      "accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
++      "sec-fetch-site: none",
++      "sec-fetch-mode: navigate",
++      "accept-language: en-US,en;q=0.9",
++      "priority: u=0, i",
++      "accept-encoding: gzip, deflate, br"
++    },
++    .http2_settings = "2:0;3:100;4:2097152;8:1;9:1",
++    .http2_window_update = 10420225,
++    .http2_pseudo_headers_order = "msap",
++    .http2_stream_weight = 256,
++    .http2_stream_exclusive = 0,
++    .tls_extension_order = NULL,
++    .tls_use_new_alps_codepoint = false,
++    .tls_signed_cert_timestamps = true,
++    .tls_grease = true
++  },
++  {
++    .target = "safari184",
++    .alias = "safari18_4",
++    .httpversion = CURL_HTTP_VERSION_2_0,
++    .ssl_version = CURL_SSLVERSION_TLSv1_0 | CURL_SSLVERSION_MAX_DEFAULT,
++    .ciphers =
++    "TLS_AES_128_GCM_SHA256,"
++    "TLS_AES_256_GCM_SHA384,"
++    "TLS_CHACHA20_POLY1305_SHA256,"
++    "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,"
++    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,"
++    "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,"
++    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,"
++    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,"
++    "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,"
++    "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,"
++    "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,"
++    "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,"
++    "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,"
++    "TLS_RSA_WITH_AES_256_GCM_SHA384,"
++    "TLS_RSA_WITH_AES_128_GCM_SHA256,"
++    "TLS_RSA_WITH_AES_256_CBC_SHA,"
++    "TLS_RSA_WITH_AES_128_CBC_SHA,"
++    "TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA,"
++    "TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,"
++    "TLS_RSA_WITH_3DES_EDE_CBC_SHA",
++    .curves = "X25519:P-256:P-384:P-521",
++    .sig_hash_algs =
++    "ecdsa_secp256r1_sha256,"
++    "rsa_pss_rsae_sha256,"
++    "rsa_pkcs1_sha256,"
++    "ecdsa_secp384r1_sha384,"
++    "rsa_pss_rsae_sha384,"
++    "rsa_pss_rsae_sha384,"
++    "rsa_pkcs1_sha384,"
++    "rsa_pss_rsae_sha512,"
++    "rsa_pkcs1_sha512,"
++    "rsa_pkcs1_sha1",
++    .npn = false,
++    .alpn = true,
++    .alps = false,
++    .tls_session_ticket = false,
++    .cert_compression = "zlib",
++    .http_headers = {
++      "sec-fetch-dest: document",
++      "user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.4 Safari/605.1.15",
++      "accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
++      "sec-fetch-site: none",
++      "sec-fetch-mode: navigate",
++      "accept-language: en-US,en;q=0.9",
++      "priority: u=0, i",
++      "accept-encoding: gzip, deflate, br"
++    },
++    .http2_settings = "2:0;3:100;4:2097152;9:1",
++    .http2_window_update = 10420225,
++    .http2_pseudo_headers_order = "msap",
++    .http2_stream_weight = 256,
++    .http2_stream_exclusive = 0,
++    .tls_extension_order = NULL,
++    .tls_use_new_alps_codepoint = false,
++    .tls_signed_cert_timestamps = true,
++    .tls_grease = true
++  },
++  {
++    .target = "safari184_ios",
++    .alias = "safari18_4_ios",
++    .httpversion = CURL_HTTP_VERSION_2_0,
++    .ssl_version = CURL_SSLVERSION_TLSv1_0 | CURL_SSLVERSION_MAX_DEFAULT,
++    .ciphers =
++    "TLS_AES_128_GCM_SHA256,"
++    "TLS_AES_256_GCM_SHA384,"
++    "TLS_CHACHA20_POLY1305_SHA256,"
++    "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,"
++    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,"
++    "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,"
++    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,"
++    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,"
++    "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,"
++    "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,"
++    "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,"
++    "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,"
++    "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,"
++    "TLS_RSA_WITH_AES_256_GCM_SHA384,"
++    "TLS_RSA_WITH_AES_128_GCM_SHA256,"
++    "TLS_RSA_WITH_AES_256_CBC_SHA,"
++    "TLS_RSA_WITH_AES_128_CBC_SHA,"
++    "TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA,"
++    "TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,"
++    "TLS_RSA_WITH_3DES_EDE_CBC_SHA",
++    .curves = "X25519:P-256:P-384:P-521",
++    .sig_hash_algs =
++    "ecdsa_secp256r1_sha256,"
++    "rsa_pss_rsae_sha256,"
++    "rsa_pkcs1_sha256,"
++    "ecdsa_secp384r1_sha384,"
++    "rsa_pss_rsae_sha384,"
++    "rsa_pss_rsae_sha384,"
++    "rsa_pkcs1_sha384,"
++    "rsa_pss_rsae_sha512,"
++    "rsa_pkcs1_sha512,"
++    "rsa_pkcs1_sha1",
++    .npn = false,
++    .alpn = true,
++    .alps = false,
++    .tls_session_ticket = false,
++    .cert_compression = "zlib",
++    .http_headers = {
++      "sec-fetch-dest: document",
++      "user-agent: Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.4 Mobile/15E148 Safari/604.1",
++      "accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
++      "sec-fetch-site: none",
++      "sec-fetch-mode: navigate",
++      "accept-language: en-US,en;q=0.9",
++      "priority: u=0, i",
++      "accept-encoding: gzip, deflate, br"
++    },
++    .http2_settings = "2:0;3:100;4:2097152;9:1",
++    .http2_window_update = 10420225,
++    .http2_pseudo_headers_order = "msap",
++    .http2_stream_weight = 256,
++    .http2_stream_exclusive = 0,
++    .tls_extension_order = NULL,
++    .tls_use_new_alps_codepoint = false,
++    .tls_signed_cert_timestamps = true,
++    .tls_grease = true
++  },
++  {
++    .target = "tor145",  // tor 14.5, based on firefox 128
++    .alias = "tor145",
++    .httpversion = CURL_HTTP_VERSION_2_0,
++    .ssl_version = CURL_SSLVERSION_TLSv1_2 | CURL_SSLVERSION_MAX_DEFAULT,
++    .ciphers =
++    "TLS_AES_128_GCM_SHA256,"
++    "TLS_CHACHA20_POLY1305_SHA256,"
++    "TLS_AES_256_GCM_SHA384,"
++    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,"
++    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,"
++    "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,"
++    "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,"
++    "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,"
++    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,"
++    "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,"
++    "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,"
++    "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,"
++    "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,"
++    "TLS_RSA_WITH_AES_128_GCM_SHA256,"
++    "TLS_RSA_WITH_AES_256_GCM_SHA384,"
++    "TLS_RSA_WITH_AES_128_CBC_SHA,"
++    "TLS_RSA_WITH_AES_256_CBC_SHA",
++    .http_headers = {
++      "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:128.0) Gecko/20100101 Firefox/128.0",
++      "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
++      "Accept-Language: en-US,en;q=0.5",
++      "Accept-Encoding: gzip, deflate, br, zstd",
++      "Sec-GPC: 1",
++      "Upgrade-Insecure-Requests: 1",
++      "Sec-Fetch-Dest: document",
++      "Sec-Fetch-Mode: navigate",
++      "Sec-Fetch-Site: none",
++      "Sec-Fetch-User: ?1",
++      "Priority: u=0, i",
++      "Te: trailers"
++    },
++    .curves = "X25519:P-256:P-384:P-521:ffdhe2048:ffdhe3072",
++    .sig_hash_algs =
++    "ecdsa_secp256r1_sha256,"
++    "ecdsa_secp384r1_sha384,"
++    "ecdsa_secp521r1_sha512,"
++    "rsa_pss_rsae_sha256,"
++    "rsa_pss_rsae_sha384,"
++    "rsa_pss_rsae_sha512,"
++    "rsa_pkcs1_sha256,"
++    "rsa_pkcs1_sha384,"
++    "rsa_pkcs1_sha512,"
++    "ecdsa_sha1,"
++    "rsa_pkcs1_sha1",
++    .alpn = true,
++    .http2_settings = "1:65536;2:0;4:131072;5:16384",
++    .http2_window_update = 12517377,
++    .http2_pseudo_headers_order = "mpas",
++    .http2_stream_exclusive = 0,
++    .cert_compression = "zlib,brotli,zstd",
++    .ech = "grease",
++    .tls_session_ticket = true,
++    .tls_extension_order = "0-23-65281-10-11-16-5-34-51-43-13-28-65037",
++    .tls_delegated_credentials = "ecdsa_secp256r1_sha256:ecdsa_secp384r1_sha384:ecdsa_secp521r1_sha512:ecdsa_sha1",
++    .tls_record_size_limit = 4001,
++    .tls_grease = false,
++    .tls_signed_cert_timestamps = true,
++    .tls_key_shares_limit = 2,
++    .use_firefox_tls13_ciphers = true
++  }
++};
++
++const size_t num_impersonations = sizeof(impersonations) / sizeof(impersonations[0]);
+diff --git a/lib/easy_lock.h b/lib/easy_lock.h
+index ec324cf..42238de 100644
+--- a/lib/easy_lock.h
++++ b/lib/easy_lock.h
+@@ -111,3 +111,65 @@ static CURL_INLINE void curl_simple_lock_unlock(curl_simple_lock *lock)
+ #endif
+ 
+ #endif /* HEADER_CURL_EASY_LOCK_H */
++
++#ifndef HEADER_CURL_IMPERSONATE_H
++#define HEADER_CURL_IMPERSONATE_H
++
++#define IMPERSONATE_MAX_HEADERS 32
++
++/*
++ * curl-impersonate: Options to be set for each supported target browser.
++ */
++struct impersonate_opts {
++  const char *target;
++  const char *alias;
++  int httpversion;
++  int ssl_version;
++  const char *ciphers;
++  /* Elliptic curves (TLS extension 10).
++   * Passed to CURLOPT_SSL_EC_CURVES */
++  const char *curves;
++  /* Signature hash algorithms (TLS extension 13).
++   * Passed to CURLOPT_SSL_SIG_HASH_ALGS */
++  const char *sig_hash_algs;
++  /* Enable TLS NPN extension. */
++  bool npn;
++  /* Enable TLS ALPN extension. */
++  bool alpn;
++  /* Enable TLS ALPS extension. */
++  bool alps;
++  /* Enable TLS session ticket extension. */
++  bool tls_session_ticket;
++  /* TLS certificate compression algorithms.
++   * (TLS extension 27) */
++  const char *cert_compression;
++  const char *http_headers[IMPERSONATE_MAX_HEADERS];
++  const char *http2_pseudo_headers_order;
++  const char *http2_settings;
++  int http2_window_update;
++  const char *http2_streams;
++  bool tls_permute_extensions;
++  bool tls_use_new_alps_codepoint;
++  bool tls_use_firefox_tls13_ciphers;
++  bool tls_signed_cert_timestamps;
++  const char *ech;
++  const char *tls_extension_order;
++  const char *tls_delegated_credentials;
++  int tls_record_size_limit;
++  int tls_key_shares_limit;  // for firefox key_shares extension
++  bool tls_grease;
++  int http2_stream_weight;
++  int http2_stream_exclusive;
++  bool use_firefox_tls13_ciphers;
++  /* Other TLS options will come here in the future once they are
++   * configurable through curl_easy_setopt() */
++};
++
++/*
++ * curl-impersonate: Global array of supported browsers and their
++ * impersonation options.
++ */
++extern const struct impersonate_opts impersonations[];
++extern const size_t num_impersonations;
++
++#endif /* HEADER_CURL_IMPERSONATE_H */
+diff --git a/lib/easyoptions.c b/lib/easyoptions.c
+index be617b5..cecda8d 100644
+--- a/lib/easyoptions.c
++++ b/lib/easyoptions.c
+@@ -134,7 +134,12 @@ struct curl_easyoption Curl_easyopts[] = {
+   {"HSTS_CTRL", CURLOPT_HSTS_CTRL, CURLOT_LONG, 0},
+   {"HTTP09_ALLOWED", CURLOPT_HTTP09_ALLOWED, CURLOT_LONG, 0},
+   {"HTTP200ALIASES", CURLOPT_HTTP200ALIASES, CURLOT_SLIST, 0},
++  {"HTTP2_PSEUDO_HEADERS_ORDER", CURLOPT_HTTP2_PSEUDO_HEADERS_ORDER, CURLOT_STRING, 0},
++  {"HTTP2_SETTINGS", CURLOPT_HTTP2_SETTINGS, CURLOT_STRING, 0},
++  {"HTTP2_STREAMS", CURLOPT_HTTP2_STREAMS, CURLOT_STRING, 0},
++  {"HTTP2_WINDOW_UPDATE", CURLOPT_HTTP2_WINDOW_UPDATE, CURLOT_LONG, 0},
+   {"HTTPAUTH", CURLOPT_HTTPAUTH, CURLOT_VALUES, 0},
++  {"HTTPBASEHEADER", CURLOPT_HTTPBASEHEADER, CURLOT_SLIST, 0},
+   {"HTTPGET", CURLOPT_HTTPGET, CURLOT_LONG, 0},
+   {"HTTPHEADER", CURLOPT_HTTPHEADER, CURLOT_SLIST, 0},
+   {"HTTPPOST", CURLOPT_HTTPPOST, CURLOT_OBJECT, 0},
+@@ -308,21 +313,27 @@ struct curl_easyoption Curl_easyopts[] = {
+   {"SSLKEYTYPE", CURLOPT_SSLKEYTYPE, CURLOT_STRING, 0},
+   {"SSLKEY_BLOB", CURLOPT_SSLKEY_BLOB, CURLOT_BLOB, 0},
+   {"SSLVERSION", CURLOPT_SSLVERSION, CURLOT_VALUES, 0},
++  {"SSL_CERT_COMPRESSION", CURLOPT_SSL_CERT_COMPRESSION, CURLOT_STRING, 0},
+   {"SSL_CIPHER_LIST", CURLOPT_SSL_CIPHER_LIST, CURLOT_STRING, 0},
+   {"SSL_CTX_DATA", CURLOPT_SSL_CTX_DATA, CURLOT_CBPTR, 0},
+   {"SSL_CTX_FUNCTION", CURLOPT_SSL_CTX_FUNCTION, CURLOT_FUNCTION, 0},
+   {"SSL_EC_CURVES", CURLOPT_SSL_EC_CURVES, CURLOT_STRING, 0},
+   {"SSL_ENABLE_ALPN", CURLOPT_SSL_ENABLE_ALPN, CURLOT_LONG, 0},
++  {"SSL_ENABLE_ALPS", CURLOPT_SSL_ENABLE_ALPS, CURLOT_LONG, 0},
+   {"SSL_ENABLE_NPN", CURLOPT_SSL_ENABLE_NPN, CURLOT_LONG, 0},
++  {"SSL_ENABLE_TICKET", CURLOPT_SSL_ENABLE_TICKET, CURLOT_LONG, 0},
+   {"SSL_FALSESTART", CURLOPT_SSL_FALSESTART, CURLOT_LONG, 0},
+   {"SSL_OPTIONS", CURLOPT_SSL_OPTIONS, CURLOT_VALUES, 0},
++  {"SSL_PERMUTE_EXTENSIONS", CURLOPT_SSL_PERMUTE_EXTENSIONS, CURLOT_LONG, 0},
+   {"SSL_SESSIONID_CACHE", CURLOPT_SSL_SESSIONID_CACHE, CURLOT_LONG, 0},
++  {"SSL_SIG_HASH_ALGS", CURLOPT_SSL_SIG_HASH_ALGS, CURLOT_STRING, 0},
+   {"SSL_VERIFYHOST", CURLOPT_SSL_VERIFYHOST, CURLOT_LONG, 0},
+   {"SSL_VERIFYPEER", CURLOPT_SSL_VERIFYPEER, CURLOT_LONG, 0},
+   {"SSL_VERIFYSTATUS", CURLOPT_SSL_VERIFYSTATUS, CURLOT_LONG, 0},
+   {"STDERR", CURLOPT_STDERR, CURLOT_OBJECT, 0},
+   {"STREAM_DEPENDS", CURLOPT_STREAM_DEPENDS, CURLOT_OBJECT, 0},
+   {"STREAM_DEPENDS_E", CURLOPT_STREAM_DEPENDS_E, CURLOT_OBJECT, 0},
++  {"STREAM_EXCLUSIVE", CURLOPT_STREAM_EXCLUSIVE, CURLOT_LONG, 0},
+   {"STREAM_WEIGHT", CURLOPT_STREAM_WEIGHT, CURLOT_LONG, 0},
+   {"SUPPRESS_CONNECT_HEADERS", CURLOPT_SUPPRESS_CONNECT_HEADERS,
+    CURLOT_LONG, 0},
+@@ -344,6 +355,16 @@ struct curl_easyoption Curl_easyopts[] = {
+   {"TLSAUTH_PASSWORD", CURLOPT_TLSAUTH_PASSWORD, CURLOT_STRING, 0},
+   {"TLSAUTH_TYPE", CURLOPT_TLSAUTH_TYPE, CURLOT_STRING, 0},
+   {"TLSAUTH_USERNAME", CURLOPT_TLSAUTH_USERNAME, CURLOT_STRING, 0},
++  {"TLS_DELEGATED_CREDENTIALS", CURLOPT_TLS_DELEGATED_CREDENTIALS, CURLOT_STRING, 0},
++  {"TLS_EXTENSION_ORDER", CURLOPT_TLS_EXTENSION_ORDER, CURLOT_STRING, 0},
++  {"TLS_GREASE", CURLOPT_TLS_GREASE, CURLOT_LONG, 0},
++  {"TLS_KEY_SHARES_LIMIT", CURLOPT_TLS_KEY_SHARES_LIMIT, CURLOT_LONG, 0},
++  {"TLS_KEY_USAGE_NO_CHECK", CURLOPT_TLS_KEY_USAGE_NO_CHECK, CURLOT_LONG, 0},
++  {"TLS_RECORD_SIZE_LIMIT", CURLOPT_TLS_RECORD_SIZE_LIMIT, CURLOT_LONG, 0},
++  {"TLS_SIGNED_CERT_TIMESTAMPS", CURLOPT_TLS_SIGNED_CERT_TIMESTAMPS, CURLOT_LONG, 0},
++  {"TLS_STATUS_REQUEST", CURLOPT_TLS_STATUS_REQUEST, CURLOT_LONG, 0},
++  {"TLS_USE_FIREFOX_TLS13_CIPHERS", CURLOPT_TLS_USE_FIREFOX_TLS13_CIPHERS, CURLOT_LONG, 0},
++  {"TLS_USE_NEW_ALPS_CODEPOINT", CURLOPT_TLS_USE_NEW_ALPS_CODEPOINT, CURLOT_LONG, 0},
+   {"TRAILERDATA", CURLOPT_TRAILERDATA, CURLOT_CBPTR, 0},
+   {"TRAILERFUNCTION", CURLOPT_TRAILERFUNCTION, CURLOT_FUNCTION, 0},
+   {"TRANSFERTEXT", CURLOPT_TRANSFERTEXT, CURLOT_LONG, 0},
+@@ -378,6 +399,6 @@ struct curl_easyoption Curl_easyopts[] = {
+  */
+ int Curl_easyopts_check(void)
+ {
+-  return (CURLOPT_LASTENTRY % 10000) != (327 + 1);
++  return ((CURLOPT_LASTENTRY%10000) != (1020 + 1));
+ }
+ #endif
+diff --git a/lib/http.c b/lib/http.c
+index 03d1959..e51b385 100644
+--- a/lib/http.c
++++ b/lib/http.c
+@@ -86,6 +86,7 @@
+ #include "ws.h"
+ #include "curl_ctype.h"
+ #include "strparse.h"
++#include "slist.h"
+ 
+ /* The last 3 #include files should be in this order */
+ #include "curl_printf.h"
+@@ -1610,6 +1611,15 @@ CURLcode Curl_add_custom_headers(struct Curl_easy *data,
+   int numlists = 1; /* by default */
+   int i;
+ 
++  /*
++   * curl-impersonate: Use the merged list of headers if it exists (i.e. when
++   * the CURLOPT_HTTPBASEHEADER option was set.
++   */
++  struct curl_slist *noproxyheaders =
++    (data->state.merged_headers ?
++     data->state.merged_headers :
++     data->set.headers);
++
+ #ifndef CURL_DISABLE_PROXY
+   enum Curl_proxy_use proxy;
+ 
+@@ -1621,10 +1631,11 @@ CURLcode Curl_add_custom_headers(struct Curl_easy *data,
+ 
+   switch(proxy) {
+   case HEADER_SERVER:
+-    h[0] = data->set.headers;
++    h[0] = noproxyheaders;
++
+     break;
+   case HEADER_PROXY:
+-    h[0] = data->set.headers;
++    h[0] = noproxyheaders;
+     if(data->set.sep_headers) {
+       h[1] = data->set.proxyheaders;
+       numlists++;
+@@ -1634,12 +1645,12 @@ CURLcode Curl_add_custom_headers(struct Curl_easy *data,
+     if(data->set.sep_headers)
+       h[0] = data->set.proxyheaders;
+     else
+-      h[0] = data->set.headers;
++      h[0] = noproxyheaders;
+     break;
+   }
+ #else
+   (void)is_connect;
+-  h[0] = data->set.headers;
++  h[0] = noproxyheaders;
+ #endif
+ 
+   /* loop through one or two lists */
+@@ -1846,6 +1857,109 @@ void Curl_http_method(struct Curl_easy *data, struct connectdata *conn,
+   *reqp = httpreq;
+ }
+ 
++/*
++ * curl-impersonate:
++ * Create a new linked list of headers.
++ * The new list is a merge between the "base" headers and the application given
++ * headers. The "base" headers contain curl-impersonate's list of headers
++ * used by default by the impersonated browser.
++ *
++ * The application given headers will override the "base" headers if supplied.
++ */
++CURLcode Curl_http_merge_headers(struct Curl_easy *data)
++{
++  int i;
++  int ret;
++  struct curl_slist *head;
++  struct curl_slist *dup = NULL;
++  struct curl_slist *new_list = NULL;
++  char *uagent;
++
++  if (!data->state.base_headers)
++    return CURLE_OK;
++
++  /* Duplicate the list for temporary use. */
++  if (data->set.headers) {
++    dup = Curl_slist_duplicate(data->set.headers);
++    if(!dup)
++      return CURLE_OUT_OF_MEMORY;
++  }
++
++  for(head = data->state.base_headers; head; head = head->next) {
++    char *sep;
++    size_t prefix_len;
++    bool found = FALSE;
++    struct curl_slist *head2;
++
++    sep = strchr(head->data, ':');
++    if(!sep)
++      continue;
++
++    prefix_len = sep - head->data;
++
++    /* Check if this header was added by the application. */
++    for(head2 = dup; head2; head2 = head2->next) {
++      if(head2->data &&
++         strncasecompare(head2->data, head->data, prefix_len) &&
++         Curl_headersep(head2->data[prefix_len]) ) {
++        new_list = curl_slist_append(new_list, head2->data);
++        /* Free and set to NULL to mark that it's been added. */
++        Curl_safefree(head2->data);
++        found = TRUE;
++        break;
++      }
++    }
++
++    /* If the user agent was set with CURLOPT_USERAGENT, but not with
++     * CURLOPT_HTTPHEADER, take it from there instead. */
++    if(!found &&
++       strncasecompare(head->data, "User-Agent", prefix_len) &&
++       data->set.str[STRING_USERAGENT] &&
++       *data->set.str[STRING_USERAGENT]) {
++      uagent = aprintf("User-Agent: %s", data->set.str[STRING_USERAGENT]);
++      if(!uagent) {
++        ret = CURLE_OUT_OF_MEMORY;
++        goto fail;
++      }
++      new_list = Curl_slist_append_nodup(new_list, uagent);
++      found = TRUE;
++    }
++
++    if (!found) {
++      new_list = curl_slist_append(new_list, head->data);
++    }
++
++    if (!new_list) {
++      ret = CURLE_OUT_OF_MEMORY;
++      goto fail;
++    }
++  }
++
++  /* Now go over any additional application-supplied headers. */
++  for(head = dup; head; head = head->next) {
++    if(head->data) {
++      new_list = curl_slist_append(new_list, head->data);
++      if(!new_list) {
++        ret = CURLE_OUT_OF_MEMORY;
++        goto fail;
++      }
++    }
++  }
++
++  curl_slist_free_all(dup);
++  /* Save the new, merged list separately, so it can be freed later. */
++  curl_slist_free_all(data->state.merged_headers);
++  data->state.merged_headers = new_list;
++
++  return CURLE_OK;
++
++fail:
++  Curl_safefree(dup);
++  curl_slist_free_all(new_list);
++  return ret;
++}
++
++
+ static CURLcode http_useragent(struct Curl_easy *data)
+ {
+   /* The User-Agent string might have been allocated in url.c already, because
+@@ -2701,6 +2815,11 @@ CURLcode Curl_http(struct Curl_easy *data, bool *done)
+   if(result)
+     goto fail;
+ 
++  /* curl-impersonate: Add HTTP headers to impersonate real browsers. */
++  result = Curl_http_merge_headers(data);
++  if(result)
++    goto fail;
++
+   result = http_host(data, conn);
+   if(result)
+     goto fail;
+@@ -4445,7 +4564,7 @@ struct name_const {
+ 
+ /* keep them sorted by length! */
+ static struct name_const H2_NON_FIELD[] = {
+-  { STRCONST("TE") },
++  // { STRCONST("TE") },
+   { STRCONST("Host") },
+   { STRCONST("Upgrade") },
+   { STRCONST("Connection") },
+@@ -4467,6 +4586,29 @@ static bool h2_non_field(const char *name, size_t namelen)
+   return FALSE;
+ }
+ 
++/*
++ * curl-impersonate:
++ * Determine the position of HTTP/2 pseudo headers.
++ * The pseudo headers ":method", ":path", ":scheme", ":authority"
++ * are sent in different order by different browsers. An important part of the
++ * impersonation is ordering them like the browser does.
++ */
++static CURLcode h2_check_pseudo_header_order(const char *order)
++{
++  if(strlen(order) != 4)
++    return CURLE_BAD_FUNCTION_ARGUMENT;
++
++  // All pseudo-headers must be present
++  if(!strchr(order, 'm') ||
++     !strchr(order, 'a') ||
++     !strchr(order, 's') ||
++     !strchr(order, 'p'))
++    return CURLE_BAD_FUNCTION_ARGUMENT;
++
++  return CURLE_OK;
++}
++
++
+ CURLcode Curl_http_req_to_h2(struct dynhds *h2_headers,
+                              struct httpreq *req, struct Curl_easy *data)
+ {
+@@ -4475,6 +4617,10 @@ CURLcode Curl_http_req_to_h2(struct dynhds *h2_headers,
+   size_t i;
+   CURLcode result;
+ 
++  // curl-impersonate: Use the Chrome ordering by default:
++  // :method, :authority, :scheme, :path
++  char *order = "masp";
++
+   DEBUGASSERT(req);
+   DEBUGASSERT(h2_headers);
+ 
+@@ -4505,25 +4651,56 @@ CURLcode Curl_http_req_to_h2(struct dynhds *h2_headers,
+ 
+   Curl_dynhds_reset(h2_headers);
+   Curl_dynhds_set_opts(h2_headers, DYNHDS_OPT_LOWERCASE);
+-  result = Curl_dynhds_add(h2_headers, STRCONST(HTTP_PSEUDO_METHOD),
+-                           req->method, strlen(req->method));
+-  if(!result && scheme) {
+-    result = Curl_dynhds_add(h2_headers, STRCONST(HTTP_PSEUDO_SCHEME),
+-                             scheme, strlen(scheme));
+-  }
+-  if(!result && authority) {
+-    result = Curl_dynhds_add(h2_headers, STRCONST(HTTP_PSEUDO_AUTHORITY),
+-                             authority, strlen(authority));
++
++  /* curl-impersonate: order of pseudo headers is different from the default */
++  if(data->set.str[STRING_HTTP2_PSEUDO_HEADERS_ORDER]) {
++    order = data->set.str[STRING_HTTP2_PSEUDO_HEADERS_ORDER];
+   }
+-  if(!result && req->path) {
+-    result = Curl_dynhds_add(h2_headers, STRCONST(HTTP_PSEUDO_PATH),
+-                             req->path, strlen(req->path));
++
++  result = h2_check_pseudo_header_order(order);
++
++  /* curl-impersonate: add http2 pseudo headers according to the specified order. */
++  for(i = 0; !result && i < strlen(order); ++i) {
++    switch(order[i]) {
++      case 'm':
++        result = Curl_dynhds_add(h2_headers, STRCONST(HTTP_PSEUDO_METHOD),
++                                 req->method, strlen(req->method));
++        break;
++      case 'a':
++        if(authority) {
++          result = Curl_dynhds_add(h2_headers, STRCONST(HTTP_PSEUDO_AUTHORITY),
++                                   authority, strlen(authority));
++        }
++        break;
++      case 's':
++        if(scheme) {
++          result = Curl_dynhds_add(h2_headers, STRCONST(HTTP_PSEUDO_SCHEME),
++                                   scheme, strlen(scheme));
++        }
++        break;
++      case 'p':
++        if(req->path) {
++          result = Curl_dynhds_add(h2_headers, STRCONST(HTTP_PSEUDO_PATH),
++                                   req->path, strlen(req->path));
++        }
++        break;
++    }
+   }
++
+   for(i = 0; !result && i < Curl_dynhds_count(&req->headers); ++i) {
+     e = Curl_dynhds_getn(&req->headers, i);
+     if(!h2_non_field(e->name, e->namelen)) {
++      /* curl-impersonate:
++       * Some HTTP/2 servers reject 'te' header value that is not lowercase (e.g. 'Trailers).
++       * Convert to lowercase explicitly.
++       */
++      if(e->namelen == 2 && strcasecompare(e->name, "te"))
++        Curl_dynhds_set_opt(h2_headers, DYNHDS_OPT_LOWERCASE_VAL);
++
+       result = Curl_dynhds_add(h2_headers, e->name, e->namelen,
+                                e->value, e->valuelen);
++      /* curl-impersonate: delete the option */
++      Curl_dynhds_del_opt(h2_headers, DYNHDS_OPT_LOWERCASE_VAL);
+     }
+   }
+ 
+diff --git a/lib/http2.c b/lib/http2.c
+index 88fbcce..94f7cd9 100644
+--- a/lib/http2.c
++++ b/lib/http2.c
+@@ -51,6 +51,7 @@
+ #include "curl_printf.h"
+ #include "curl_memory.h"
+ #include "memdebug.h"
++#include "rand.h"
+ 
+ #if (NGHTTP2_VERSION_NUM < 0x010c00)
+ #error too old nghttp2 version, upgrade!
+@@ -75,11 +76,13 @@
+ /* on send into TLS, we just want to accumulate small frames */
+ #define H2_NW_SEND_CHUNKS       1
+ /* this is how much we want "in flight" for a stream, unthrottled  */
+-#define H2_STREAM_WINDOW_SIZE_MAX   (10 * 1024 * 1024)
++/* curl-impersonate: match Chrome window size. */
++#define H2_STREAM_WINDOW_SIZE_MAX   (1024 * 1024)
+ /* this is how much we want "in flight" for a stream, initially, IFF
+  * nghttp2 allows us to tweak the local window size. */
+ #if NGHTTP2_HAS_SET_LOCAL_WINDOW_SIZE
+-#define H2_STREAM_WINDOW_SIZE_INITIAL  (64 * 1024)
++/* curl-impersonate: match Chrome window size. */
++#define H2_STREAM_WINDOW_SIZE_INITIAL  (1024 * 1024)
+ #else
+ #define H2_STREAM_WINDOW_SIZE_INITIAL H2_STREAM_WINDOW_SIZE_MAX
+ #endif
+@@ -93,24 +96,95 @@
+  * the overall connection. Streams might become PAUSED which will block their
+  * received QUOTA in the connection window. If we run out of space, the server
+  * is blocked from sending us any data. See #10988 for an issue with this. */
+-#define HTTP2_HUGE_WINDOW_SIZE (100 * H2_STREAM_WINDOW_SIZE_MAX)
++/* curl-impersonate: match Chrome window size. */
++#define HTTP2_HUGE_WINDOW_SIZE (15 * H2_STREAM_WINDOW_SIZE_MAX)
+ 
+-#define H2_SETTINGS_IV_LEN  3
++#define H2_SETTINGS_IV_LEN  8
+ #define H2_BINSETTINGS_LEN 80
+ 
+ static size_t populate_settings(nghttp2_settings_entry *iv,
+                                 struct Curl_easy *data)
+ {
+-  iv[0].settings_id = NGHTTP2_SETTINGS_MAX_CONCURRENT_STREAMS;
+-  iv[0].value = Curl_multi_max_concurrent_streams(data->multi);
++  // curl-impersonate:
++  // Setting http2 settings frame based on user instruction.
++  // https://httpwg.org/specs/rfc7540.html#SETTINGS
++  // Format example: 1:65536;2:0;4:6291456;6:262144
++
++  // TODO check if the http2 settings is valid
++  int i = 0;
++  char *delimiter = ";";
+ 
+-  iv[1].settings_id = NGHTTP2_SETTINGS_INITIAL_WINDOW_SIZE;
+-  iv[1].value = H2_STREAM_WINDOW_SIZE_INITIAL;
++  // Use chrome's settings as default
++  char *http2_settings = "1:65536;2:0;4:6291456;6:262144";
++  if(data->set.str[STRING_HTTP2_SETTINGS]) {
++    http2_settings = data->set.str[STRING_HTTP2_SETTINGS];
++  }
+ 
+-  iv[2].settings_id = NGHTTP2_SETTINGS_ENABLE_PUSH;
+-  iv[2].value = data->multi->push_cb != NULL;
++  // printf("USING settings %s\n", http2_settings);
+ 
+-  return 3;
++  char *tmp = strdup(http2_settings);
++  char *setting = strtok(tmp, delimiter);
++
++  // loop through the string to extract all other tokens
++  while(setting != NULL) {
++    // deal with each setting
++    switch(setting[0]) {
++      case '1':
++        iv[i].settings_id = NGHTTP2_SETTINGS_HEADER_TABLE_SIZE;
++        iv[i].value = atoi(setting + 2);
++        i++;
++        break;
++      case '2':
++        iv[i].settings_id = NGHTTP2_SETTINGS_ENABLE_PUSH;
++        iv[i].value = atoi(setting + 2);
++        i++;
++        break;
++      case '3':
++        // FIXME We also need to notify curl_multi about this setting
++        iv[i].settings_id = NGHTTP2_SETTINGS_MAX_CONCURRENT_STREAMS;
++        iv[i].value = atoi(setting + 2);
++        i++;
++        break;
++      case '4':
++        iv[i].settings_id = NGHTTP2_SETTINGS_INITIAL_WINDOW_SIZE;
++        iv[i].value = atoi(setting + 2);
++        i++;
++        break;
++      case '5':
++        iv[i].settings_id = NGHTTP2_SETTINGS_MAX_FRAME_SIZE;
++        iv[i].value = atoi(setting + 2);
++        i++;
++        break;
++      case '6':
++        iv[i].settings_id = NGHTTP2_SETTINGS_MAX_HEADER_LIST_SIZE;
++        iv[i].value = atoi(setting + 2);
++        i++;
++        break;
++      // https://tools.ietf.org/html/rfc8441
++      case '8':
++        iv[i].settings_id = NGHTTP2_SETTINGS_ENABLE_CONNECT_PROTOCOL;
++        iv[i].value = atoi(setting + 2);
++        i++;
++        break;
++      // https://tools.ietf.org/html/rfc9218
++      case '9':
++        iv[i].settings_id = NGHTTP2_SETTINGS_NO_RFC7540_PRIORITIES;
++        iv[i].value = atoi(setting + 2);
++        i++;
++        break;
++    }
++    setting = strtok(NULL, delimiter);
++  }
++  free(tmp);
++
++  // curl-impersonate:
++  // Up until Chrome 98, there was a randomly chosen setting number in the
++  // HTTP2 SETTINGS frame. This might be something similar to TLS GREASE.
++  // However, it seems to have been removed since.
++  // Curl_rand(data, (unsigned char *)&iv[4].settings_id, sizeof(iv[4].settings_id));
++  // Curl_rand(data, (unsigned char *)&iv[4].value, sizeof(iv[4].value));
++
++  return i;
+ }
+ 
+ static ssize_t populate_binsettings(uint8_t *binsettings,
+@@ -189,6 +263,76 @@ static void cf_h2_ctx_close(struct cf_h2_ctx *ctx)
+   }
+ }
+ 
++static CURLcode http2_set_stream_priority(struct Curl_cfilter *cf,
++                                          struct Curl_easy *data,
++                                          int32_t stream_id,
++                                          int32_t dep_stream_id,
++                                          int32_t weight,
++                                          int exclusive
++                                          )
++{
++  int rv;
++  struct cf_h2_ctx *ctx = cf->ctx;
++  nghttp2_priority_spec pri_spec;
++
++  nghttp2_priority_spec_init(&pri_spec, dep_stream_id, weight, exclusive);
++  rv = nghttp2_submit_priority(ctx->h2, NGHTTP2_FLAG_NONE,
++                               stream_id, &pri_spec);
++  if(rv) {
++    failf(data, "nghttp2_submit_priority() failed: %s(%d)",
++          nghttp2_strerror(rv), rv);
++    return CURLE_HTTP2;
++  }
++
++  return CURLE_OK;
++}
++
++/*
++ * curl-impersonate: Firefox uses an elaborate scheme of http/2 streams to
++ * split the load for html/js/css/images. It builds a tree of streams with
++ * different weights (priorities) by default and communicates this to the
++ * server. Imitate that behavior.
++ */
++static CURLcode http2_set_stream_priorities(struct Curl_cfilter *cf,
++                                            struct Curl_easy *data)
++{
++  CURLcode result;
++  char *stream_delimiter = ",";
++  char *value_delimiter = ":";
++
++  if(!data->set.str[STRING_HTTP2_STREAMS])
++    return CURLE_OK;
++
++  char *tmp1 = strdup(data->set.str[STRING_HTTP2_STREAMS]);
++  char *end1;
++  char *stream = strtok_r(tmp1, stream_delimiter, &end1);
++
++  while(stream != NULL) {
++
++    char *tmp2 = strdup(stream);
++    char *end2;
++
++    int32_t stream_id = atoi(strtok_r(tmp2, value_delimiter, &end2));
++    int exclusive = atoi(strtok_r(NULL, value_delimiter, &end2));
++    int32_t dep_stream_id = atoi(strtok_r(NULL, value_delimiter, &end2));
++    int32_t weight = atoi(strtok_r(NULL, value_delimiter, &end2));
++
++    free(tmp2);
++
++    result = http2_set_stream_priority(cf, data, stream_id, dep_stream_id, weight, exclusive);
++    if(result) {
++      free(tmp1);
++      return result;
++    }
++
++    stream = strtok_r(NULL, stream_delimiter, &end1);
++  }
++
++  free(tmp1);
++  return CURLE_OK;
++}
++
++
+ static CURLcode h2_progress_egress(struct Curl_cfilter *cf,
+                                   struct Curl_easy *data);
+ 
+@@ -314,8 +458,6 @@ static CURLcode cf_h2_update_local_win(struct Curl_cfilter *cf,
+                   stream->id, dwsize - wsize);
+     }
+     else {
+-      rv = nghttp2_session_set_local_window_size(ctx->h2, NGHTTP2_FLAG_NONE,
+-                                                 stream->id, dwsize);
+       if(rv) {
+         failf(data, "[%d] nghttp2_session_set_local_window_size() failed: "
+               "%s(%d)", stream->id, nghttp2_strerror(rv), rv);
+@@ -600,9 +742,23 @@ static CURLcode cf_h2_ctx_open(struct Curl_cfilter *cf,
+       goto out;
+     }
+   }
++  
++  // curl-impersonate:
++  // Directly changing the initial window update using users' settings.
++  int current_window_size = nghttp2_session_get_local_window_size(ctx->h2);
++
++  // Use chrome's value as default
++  int window_update = 15663105;
++  if(data->set.http2_window_update) {
++    window_update = data->set.http2_window_update;
++  }
++
++  // printf("Using window update %d\n", window_update);
++
++  rc = nghttp2_session_set_local_window_size(
++      ctx->h2, NGHTTP2_FLAG_NONE, 0,
++      current_window_size + window_update);
+ 
+-  rc = nghttp2_session_set_local_window_size(ctx->h2, NGHTTP2_FLAG_NONE, 0,
+-                                             HTTP2_HUGE_WINDOW_SIZE);
+   if(rc) {
+     failf(data, "nghttp2_session_set_local_window_size() failed: %s(%d)",
+           nghttp2_strerror(rc), rc);
+@@ -610,6 +766,17 @@ static CURLcode cf_h2_ctx_open(struct Curl_cfilter *cf,
+     goto out;
+   }
+ 
++  // curl-impersonate: set stream priorities
++  result = http2_set_stream_priorities(cf, data);
++  if(result)
++    goto out;
++
++#define FIREFOX_DEFAULT_STREAM_ID   (15)
++  /* Best effort to set the request's stream id to 15, like Firefox does. */
++  // Let's ignore this for now, as it seems not to be targeted as fingerprints.
++  // nghttp2_session_set_next_stream_id(ctx->h2, FIREFOX_DEFAULT_STREAM_ID);
++
++
+   /* all set, traffic will be send on connect */
+   result = CURLE_OK;
+   CURL_TRC_CF(data, cf, "[0] created h2 session%s",
+@@ -1925,11 +2092,19 @@ out:
+   return rv;
+ }
+ 
++/*
++ * curl-impersonate: Use Chrome's default HTTP/2 stream weight
++ * instead of NGINX default stream weight.
++ */
++#define CHROME_DEFAULT_STREAM_WEIGHT    (256)
++#define SAFARI_DEFAULT_STREAM_WEIGHT    (255)
++#define FIREFOX_DEFAULT_STREAM_WEIGHT   (42)
++
+ static int sweight_wanted(const struct Curl_easy *data)
+ {
+   /* 0 weight is not set by user and we take the nghttp2 default one */
+   return data->set.priority.weight ?
+-    data->set.priority.weight : NGHTTP2_DEFAULT_WEIGHT;
++    data->set.priority.weight : CHROME_DEFAULT_STREAM_WEIGHT;
+ }
+ 
+ static int sweight_in_effect(const struct Curl_easy *data)
+@@ -1944,6 +2119,12 @@ static int sweight_in_effect(const struct Curl_easy *data)
+  * and dependency to the peer. It also stores the updated values in the state
+  * struct.
+  */
++/*
++ * curl-impersonate: By default Firefox uses stream 13 as the "parent" of the
++ * stream that fetches the main html resource of the web page.
++ */
++#define FIREFOX_DEFAULT_STREAM_DEP  (13)
++
+ 
+ static void h2_pri_spec(struct cf_h2_ctx *ctx,
+                         struct Curl_easy *data,
+@@ -1952,6 +2133,11 @@ static void h2_pri_spec(struct cf_h2_ctx *ctx,
+   struct Curl_data_priority *prio = &data->set.priority;
+   struct h2_stream_ctx *depstream = H2_STREAM_CTX(ctx, prio->parent);
+   int32_t depstream_id = depstream ? depstream->id : 0;
++  // int32_t depstream_id = depstream? depstream->id:FIREFOX_DEFAULT_STREAM_DEP;
++
++  /* curl-impersonate: Set stream exclusive flag based on user option.
++   * Use data->set, not data->state.
++   */
+   nghttp2_priority_spec_init(pri_spec, depstream_id,
+                              sweight_wanted(data),
+                              data->set.priority.exclusive);
+@@ -1971,20 +2157,24 @@ static CURLcode h2_progress_egress(struct Curl_cfilter *cf,
+   struct h2_stream_ctx *stream = H2_STREAM_CTX(ctx, data);
+   int rv = 0;
+ 
++  /* curl-impersonate: Check if stream exclusive flag is true. */
+   if(stream && stream->id > 0 &&
+      ((sweight_wanted(data) != sweight_in_effect(data)) ||
+-      (data->set.priority.exclusive != data->state.priority.exclusive) ||
++     (data->set.priority.exclusive != 1) ||
+       (data->set.priority.parent != data->state.priority.parent)) ) {
+     /* send new weight and/or dependency */
+     nghttp2_priority_spec pri_spec;
+ 
+     h2_pri_spec(ctx, data, &pri_spec);
+-    CURL_TRC_CF(data, cf, "[%d] Queuing PRIORITY", stream->id);
+-    DEBUGASSERT(stream->id != -1);
+-    rv = nghttp2_submit_priority(ctx->h2, NGHTTP2_FLAG_NONE,
+-                                 stream->id, &pri_spec);
+-    if(rv)
+-      goto out;
++    /* curl-impersonate: Don't send PRIORITY frames for main stream. */
++    if(stream->id != 1) {
++      CURL_TRC_CF(data, cf, "[%d] Queuing PRIORITY", stream->id);
++      DEBUGASSERT(stream->id != -1);
++      rv = nghttp2_submit_priority(ctx->h2, NGHTTP2_FLAG_NONE,
++                                   stream->id, &pri_spec);
++      if(rv)
++        goto out;
++    }
+   }
+ 
+   ctx->nw_out_blocked = 0;
+diff --git a/lib/http2.h b/lib/http2.h
+index 93cc2d4..52e80ce 100644
+--- a/lib/http2.h
++++ b/lib/http2.h
+@@ -31,7 +31,8 @@
+ 
+ /* value for MAX_CONCURRENT_STREAMS we use until we get an updated setting
+    from the peer */
+-#define DEFAULT_MAX_CONCURRENT_STREAMS 100
++/* curl-impersonate: Use 1000 concurrent streams like Chrome. */
++#define DEFAULT_MAX_CONCURRENT_STREAMS 1000
+ 
+ /*
+  * Store nghttp2 version info in this buffer.
+diff --git a/lib/libcurl.def b/lib/libcurl.def
+index 43e26f6..8537a10 100644
+--- a/lib/libcurl.def
++++ b/lib/libcurl.def
+@@ -5,6 +5,7 @@ curl_easy_escape
+ curl_easy_getinfo
+ curl_easy_header
+ curl_easy_init
++curl_easy_impersonate
+ curl_easy_nextheader
+ curl_easy_option_by_id
+ curl_easy_option_by_name
+diff --git a/lib/multi.c b/lib/multi.c
+index 09afe80..4bdc3ee 100644
+--- a/lib/multi.c
++++ b/lib/multi.c
+@@ -254,7 +254,8 @@ struct Curl_multi *Curl_multi_handle(size_t ev_hashsize,  /* event hash */
+   Curl_llist_init(&multi->msgsent, NULL);
+ 
+   multi->multiplexing = TRUE;
+-  multi->max_concurrent_streams = 100;
++  /* curl-impersonate: Use 1000 concurrent streams like Chrome. */
++  multi->max_concurrent_streams = 1000;
+   multi->last_timeout_ms = -1;
+ 
+ #ifdef USE_WINSOCK
+diff --git a/lib/setopt.c b/lib/setopt.c
+index 4833229..8817103 100644
+--- a/lib/setopt.c
++++ b/lib/setopt.c
+@@ -51,6 +51,7 @@
+ #include "altsvc.h"
+ #include "hsts.h"
+ #include "tftp.h"
++#include "slist.h"
+ #include "strdup.h"
+ #include "escape.h"
+ 
+@@ -629,6 +630,11 @@ static CURLcode setopt_long(struct Curl_easy *data, CURLoption option,
+     }
+     data->set.httpwant = (unsigned char)arg;
+     break;
++#ifdef USE_HTTP2
++  case CURLOPT_STREAM_EXCLUSIVE:
++    data->set.priority.exclusive = (int)arg;
++    break;
++#endif
+ 
+   case CURLOPT_EXPECT_100_TIMEOUT_MS:
+     /*
+@@ -1314,6 +1320,35 @@ static CURLcode setopt_long(struct Curl_easy *data, CURLoption option,
+   case CURLOPT_SSL_ENABLE_ALPN:
+     data->set.ssl_enable_alpn = enabled;
+     break;
++  case CURLOPT_SSL_ENABLE_ALPS:
++    data->set.ssl_enable_alps = enabled;
++    break;
++  case CURLOPT_SSL_ENABLE_TICKET:
++    data->set.ssl_enable_ticket = enabled;
++    break;
++  case CURLOPT_SSL_PERMUTE_EXTENSIONS:
++    data->set.ssl_permute_extensions = enabled;
++    break;
++  case CURLOPT_TLS_GREASE:
++    data->set.tls_grease = enabled;
++    break;
++  case CURLOPT_TLS_KEY_USAGE_NO_CHECK:
++    data->set.tls_key_usage_no_check = enabled;
++    break;
++  case CURLOPT_TLS_SIGNED_CERT_TIMESTAMPS:
++    data->set.tls_signed_cert_timestamps = enabled;
++    break;
++  case CURLOPT_TLS_STATUS_REQUEST:
++    data->set.tls_status_request = enabled;
++    break;
++
++#ifdef USE_HTTP2
++  case CURLOPT_HTTP2_WINDOW_UPDATE:
++    if(arg < -1)
++      return CURLE_BAD_FUNCTION_ARGUMENT;
++    data->set.http2_window_update = arg;
++    break;
++#endif
+   case CURLOPT_PATH_AS_IS:
+     data->set.path_as_is = enabled;
+     break;
+@@ -1360,6 +1395,19 @@ static CURLcode setopt_long(struct Curl_easy *data, CURLoption option,
+       return CURLE_BAD_FUNCTION_ARGUMENT;
+     data->set.maxlifetime_conn = arg;
+     break;
++  case CURLOPT_TLS_RECORD_SIZE_LIMIT:
++    data->set.tls_record_size_limit = arg;
++    break;
++  case CURLOPT_TLS_KEY_SHARES_LIMIT:
++    data->set.tls_key_shares_limit = arg;
++    break;
++  case CURLOPT_TLS_USE_NEW_ALPS_CODEPOINT:
++    data->set.tls_use_new_alps_codepoint = enabled;
++    break;
++  case CURLOPT_TLS_USE_FIREFOX_TLS13_CIPHERS:
++    data->set.tls_use_firefox_tls13_ciphers = enabled;
++    break;
++
+ #ifndef CURL_DISABLE_HSTS
+   case CURLOPT_HSTS_CTRL:
+     if(arg & CURLHSTS_ENABLE) {
+@@ -1485,6 +1533,21 @@ static CURLcode setopt_slist(struct Curl_easy *data, CURLoption option,
+      */
+     data->set.headers = slist;
+     break;
++  case CURLOPT_HTTPBASEHEADER:
++    /*
++     * curl-impersonate:
++     * Set a list of "base" headers. These will be merged with any headers
++     * set by CURLOPT_HTTPHEADER. curl-impersonate uses this option in order
++     * to set a list of default browser headers.
++     *
++     * Unlike CURLOPT_HTTPHEADER,
++     * the list is copied and can be immediately freed by the user.
++     */
++    curl_slist_free_all(data->state.base_headers);
++    data->state.base_headers = Curl_slist_duplicate(slist);
++    if (!data->state.base_headers)
++      result = CURLE_OUT_OF_MEMORY;
++    break;
+ #endif
+ #ifndef CURL_DISABLE_TELNET
+   case CURLOPT_TELNETOPTIONS:
+@@ -1680,6 +1743,39 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
+     }
+     else
+       return CURLE_NOT_BUILT_IN;
++  // curl-impersonate
++  case CURLOPT_TLS_EXTENSION_ORDER:
++    return Curl_setstropt(&data->set.str[STRING_TLS_EXTENSION_ORDER], ptr);
++    break;
++  case CURLOPT_HTTP2_PSEUDO_HEADERS_ORDER:
++    return Curl_setstropt(&data->set.str[STRING_HTTP2_PSEUDO_HEADERS_ORDER], ptr);
++    break;
++  case CURLOPT_HTTP2_SETTINGS:
++    return Curl_setstropt(&data->set.str[STRING_HTTP2_SETTINGS], ptr);
++    break;
++  case CURLOPT_HTTP2_STREAMS:
++    return Curl_setstropt(&data->set.str[STRING_HTTP2_STREAMS], ptr);
++    break;
++  case CURLOPT_SSL_SIG_HASH_ALGS:
++    /*
++     * Set the list of hash algorithms we want to use in the SSL connection.
++     * Specify comma-delimited list of algorithms to use.
++     */
++    return Curl_setstropt(&data->set.str[STRING_SSL_SIG_HASH_ALGS], ptr);
++    break;
++  case CURLOPT_SSL_CERT_COMPRESSION:
++    /*
++     * Set the list of ceritifcate compression algorithms we support in the TLS
++     * connection.
++     * Specify comma-delimited list of algorithms to use. Options are "zlib"
++     * and "brotli".
++     */
++    return Curl_setstropt(&data->set.str[STRING_SSL_CERT_COMPRESSION], ptr);
++    break;
++  case CURLOPT_TLS_DELEGATED_CREDENTIALS:
++    return Curl_setstropt(&data->set.str[STRING_TLS_DELEGATED_CREDENTIALS], ptr);
++    break;
++
+ #ifndef CURL_DISABLE_PROXY
+   case CURLOPT_PROXY_TLS13_CIPHERS:
+     if(Curl_ssl_supports(data, SSLSUPP_TLS13_CIPHERSUITES))
+@@ -3021,6 +3117,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
+        way than being listed explicitly */
+     switch(option) {
+     case CURLOPT_HTTPHEADER:
++    case CURLOPT_HTTPBASEHEADER:
+     case CURLOPT_QUOTE:
+     case CURLOPT_POSTQUOTE:
+     case CURLOPT_TELNETOPTIONS:
+diff --git a/lib/transfer.c b/lib/transfer.c
+index 754bc2c..8ca6339 100644
+--- a/lib/transfer.c
++++ b/lib/transfer.c
+@@ -105,7 +105,15 @@ char *Curl_checkheaders(const struct Curl_easy *data,
+   DEBUGASSERT(thislen);
+   DEBUGASSERT(thisheader[thislen-1] != ':');
+ 
+-  for(head = data->set.headers; head; head = head->next) {
++  /*
++   * curl-impersonate:
++   * Check if we have overriden the user-supplied list of headers.
++   */
++  head = data->set.headers;
++  if (data->state.merged_headers)
++    head = data->state.merged_headers;
++
++  for(; head; head = head->next) {
+     if(strncasecompare(head->data, thisheader, thislen) &&
+        Curl_headersep(head->data[thislen]) )
+       return head->data;
+diff --git a/lib/url.c b/lib/url.c
+index 2125a97..644038c 100644
+--- a/lib/url.c
++++ b/lib/url.c
+@@ -325,6 +325,10 @@ CURLcode Curl_close(struct Curl_easy **datap)
+   Curl_safefree(data->state.aptr.proxyuser);
+   Curl_safefree(data->state.aptr.proxypasswd);
+ #endif
++  /* curl-impersonate: Free the list set by CURLOPT_HTTPBASEHEADER. */
++  curl_slist_free_all(data->state.base_headers);
++  /* curl-impersonate: Free the dynamic list of headers. */
++  curl_slist_free_all(data->state.merged_headers);
+ 
+ #if !defined(CURL_DISABLE_HTTP) && !defined(CURL_DISABLE_FORM_API)
+   Curl_mime_cleanpart(data->state.formp);
+@@ -465,6 +469,9 @@ CURLcode Curl_init_userdefined(struct Curl_easy *data)
+   set->tcp_fastopen = FALSE;
+   set->tcp_nodelay = TRUE;
+   set->ssl_enable_alpn = TRUE;
++  set->ssl_enable_ticket = TRUE;
++  set->tls_grease = FALSE;
++  set->tls_use_new_alps_codepoint = FALSE;
+   set->expect_100_timeout = 1000L; /* Wait for a second by default. */
+   set->sep_headers = TRUE; /* separated header lists by default */
+   set->buffer_size = READBUFFER_SIZE;
+@@ -3595,6 +3602,11 @@ static CURLcode create_conn(struct Curl_easy *data,
+          (default) */
+       if(data->set.ssl_enable_alpn)
+         conn->bits.tls_enable_alpn = TRUE;
++
++      /* curl-impersonate: Turn on ALPS if ALPN is enabled and the bit is
++       * enabled. */
++      if(data->set.ssl_enable_alps)
++        conn->bits.tls_enable_alps = TRUE;
+     }
+ 
+     if(waitpipe)
+diff --git a/lib/urldata.h b/lib/urldata.h
+index e4487ba..3c3f024 100644
+--- a/lib/urldata.h
++++ b/lib/urldata.h
+@@ -283,6 +283,8 @@ struct ssl_primary_config {
+   char *password; /* TLS password (for, e.g., SRP) */
+ #endif
+   char *curves;          /* list of curves to use */
++  char *sig_hash_algs;   /* List of signature hash algorithms to use */
++  char *cert_compression;  /* List of certificate compression algorithms. */
+   unsigned char ssl_options;  /* the CURLOPT_SSL_OPTIONS bitmask */
+   unsigned int version_max; /* max supported version the client wants to use */
+   unsigned char version;    /* what version the client wants to use */
+@@ -508,6 +510,12 @@ struct ConnectBits {
+   BIT(multiplex); /* connection is multiplexed */
+   BIT(tcp_fastopen); /* use TCP Fast Open */
+   BIT(tls_enable_alpn); /* TLS ALPN extension? */
++  BIT(tls_enable_alps); /* TLS ALPS extension? */
++  BIT(tls_enable_ticket); /* TLS session ticket extension? */
++  BIT(tls_permute_extensions); /* TLS extension permutations */
++  BIT(tls_use_new_alps_codepoint); /* TLS ALPS new codepoint */
++  BIT(tls_use_firefox_tls13_ciphers);
++  BIT(tls_grease);  /* TLS grease? */
+ #ifndef CURL_DISABLE_DOH
+   BIT(doh);
+ #endif
+@@ -1275,6 +1283,19 @@ struct UrlState {
+                                     curl_easy_setopt(COOKIEFILE) calls */
+ #endif
+ 
++  /*
++   * curl-impersonate:
++   * List of "base" headers set by CURLOPT_HTTPBASEHEADER.
++   */
++  struct curl_slist *base_headers;
++  /*
++   * curl-impersonate:
++   * Dynamically-constructed list of HTTP headers.
++   * This list is a merge of the default HTTP headers needed to impersonate a
++   * browser, together with any user-supplied headers.
++   */
++  struct curl_slist *merged_headers;
++
+ #ifndef CURL_DISABLE_VERBOSE_STRINGS
+   struct curl_trc_feat *feat; /* opt. trace feature transfer is part of */
+ #endif
+@@ -1493,6 +1514,13 @@ enum dupstring {
+ #endif
+   STRING_ECH_CONFIG,            /* CURLOPT_ECH_CONFIG */
+   STRING_ECH_PUBLIC,            /* CURLOPT_ECH_PUBLIC */
++  STRING_SSL_SIG_HASH_ALGS,
++  STRING_SSL_CERT_COMPRESSION,
++  STRING_HTTP2_PSEUDO_HEADERS_ORDER,
++  STRING_HTTP2_SETTINGS,
++  STRING_HTTP2_STREAMS,
++  STRING_TLS_EXTENSION_ORDER,
++  STRING_TLS_DELEGATED_CREDENTIALS,
+ 
+   /* -- end of null-terminated strings -- */
+ 
+@@ -1808,6 +1836,15 @@ struct UserDefined {
+   BIT(tcp_keepalive);  /* use TCP keepalives */
+   BIT(tcp_fastopen);   /* use TCP Fast Open */
+   BIT(ssl_enable_alpn);/* TLS ALPN extension? */
++  BIT(ssl_enable_alps);/* TLS ALPS extension? */
++  BIT(ssl_enable_ticket); /* TLS session ticket extension */
++  BIT(ssl_permute_extensions); /* TLS Permute extensions */
++  BIT(tls_grease);  /* TLS grease? */
++  BIT(tls_key_usage_no_check);  /* TLS key_usage_check? */
++  BIT(tls_signed_cert_timestamps);  /* TLS signed cert timestamps? */
++  BIT(tls_status_request);  /* TLS status request */
++  BIT(tls_use_new_alps_codepoint); /* TLS use new alps codepoint */
++  BIT(tls_use_firefox_tls13_ciphers);
+   BIT(path_as_is);     /* allow dotdots? */
+   BIT(pipewait);       /* wait for multiplex status before starting a new
+                           connection */
+@@ -1829,9 +1866,13 @@ struct UserDefined {
+   BIT(doh_verifystatus);   /* DoH certificate status verification */
+ #endif
+   BIT(http09_allowed); /* allow HTTP/0.9 responses */
++// BIT(grease);           /* grease enabled? */
+ #ifndef CURL_DISABLE_WEBSOCKETS
+   BIT(ws_raw_mode);
+ #endif
++  int http2_window_update;
++  int tls_record_size_limit;
++  int tls_key_shares_limit;
+ };
+ 
+ #ifndef CURL_DISABLE_MIME
+diff --git a/lib/vtls/openssl.c b/lib/vtls/openssl.c
+index 4d5e1be..479042f 100644
+--- a/lib/vtls/openssl.c
++++ b/lib/vtls/openssl.c
+@@ -81,9 +81,21 @@
+ #include <openssl/bio.h>
+ #include <openssl/buffer.h>
+ #include <openssl/pkcs12.h>
++#include <openssl/pool.h>
+ #include <openssl/tls1.h>
+ #include <openssl/evp.h>
+ 
++#ifdef HAVE_LIBZ
++#include <zlib.h>
++#endif
++#ifdef HAVE_BROTLI
++#include <brotli/decode.h>
++#endif
++#ifdef HAVE_ZSTD
++#include <zstd.h>
++#endif
++
++
+ #ifdef HAVE_SSL_SET1_ECH_CONFIG_LIST
+ #define USE_ECH_OPENSSL
+ #endif
+@@ -242,6 +254,114 @@ typedef int numcert_t;
+ #define HAVE_OPENSSL_VERSION
+ #endif
+ 
++#if defined(OPENSSL_IS_BORINGSSL)
++#define HAVE_SSL_CTX_SET_VERIFY_ALGORITHM_PREFS
++
++/*
++ * kMaxSignatureAlgorithmNameLen and kSignatureAlgorithmNames
++ * Taken from BoringSSL, see ssl/ssl_privkey.cc
++ * */
++static const size_t kMaxSignatureAlgorithmNameLen = 23;
++
++static const struct {
++  uint16_t signature_algorithm;
++  const char *name;
++} kSignatureAlgorithmNames[] = {
++    {SSL_SIGN_RSA_PKCS1_MD5_SHA1, "rsa_pkcs1_md5_sha1"},
++    {SSL_SIGN_RSA_PKCS1_SHA1, "rsa_pkcs1_sha1"},
++    {SSL_SIGN_RSA_PKCS1_SHA256, "rsa_pkcs1_sha256"},
++    {SSL_SIGN_RSA_PKCS1_SHA384, "rsa_pkcs1_sha384"},
++    {SSL_SIGN_RSA_PKCS1_SHA512, "rsa_pkcs1_sha512"},
++    {SSL_SIGN_ECDSA_SHA1, "ecdsa_sha1"},
++    {SSL_SIGN_ECDSA_SECP256R1_SHA256, "ecdsa_secp256r1_sha256"},
++    {SSL_SIGN_ECDSA_SECP384R1_SHA384, "ecdsa_secp384r1_sha384"},
++    {SSL_SIGN_ECDSA_SECP521R1_SHA512, "ecdsa_secp521r1_sha512"},
++    {SSL_SIGN_RSA_PSS_RSAE_SHA256, "rsa_pss_rsae_sha256"},
++    {SSL_SIGN_RSA_PSS_RSAE_SHA384, "rsa_pss_rsae_sha384"},
++    {SSL_SIGN_RSA_PSS_RSAE_SHA512, "rsa_pss_rsae_sha512"},
++    {SSL_SIGN_ED25519, "ed25519"},
++};
++
++#define MAX_SIG_ALGS \
++  sizeof(kSignatureAlgorithmNames) / sizeof(kSignatureAlgorithmNames[0])
++
++/* Default signature hash algorithms taken from Chrome/Chromium.
++ * See kVerifyPeers @ net/socket/ssl_client_socket_impl.cc */
++static const uint16_t default_sig_algs[] = {
++  SSL_SIGN_ECDSA_SECP256R1_SHA256, SSL_SIGN_RSA_PSS_RSAE_SHA256,
++  SSL_SIGN_RSA_PKCS1_SHA256,       SSL_SIGN_ECDSA_SECP384R1_SHA384,
++  SSL_SIGN_RSA_PSS_RSAE_SHA384,    SSL_SIGN_RSA_PKCS1_SHA384,
++  SSL_SIGN_RSA_PSS_RSAE_SHA512,    SSL_SIGN_RSA_PKCS1_SHA512,
++};
++
++#define DEFAULT_SIG_ALGS_LENGTH  \
++  sizeof(default_sig_algs) / sizeof(default_sig_algs[0])
++
++static CURLcode parse_sig_algs(struct Curl_easy *data,
++                               const char *sigalgs,
++                               uint16_t *algs,
++                               size_t *nalgs)
++{
++  *nalgs = 0;
++  while (sigalgs && sigalgs[0]) {
++    int i;
++    bool found = FALSE;
++    const char *end;
++    size_t len;
++    char algname[kMaxSignatureAlgorithmNameLen + 1];
++
++    end = strpbrk(sigalgs, ":,");
++    if (end)
++      len = end - sigalgs;
++    else
++      len = strlen(sigalgs);
++
++    if (len > kMaxSignatureAlgorithmNameLen) {
++      failf(data, "Bad signature hash algorithm list");
++      return CURLE_BAD_FUNCTION_ARGUMENT;
++    }
++
++    if (!len) {
++      ++sigalgs;
++      continue;
++    }
++
++    if (*nalgs == MAX_SIG_ALGS) {
++      /* Reached the maximum number of possible algorithms, but more data
++       * available in the list. */
++      failf(data, "Bad signature hash algorithm list");
++      return CURLE_BAD_FUNCTION_ARGUMENT;
++    }
++
++    memcpy(algname, sigalgs, len);
++    algname[len] = 0;
++
++    for (i = 0; i < MAX_SIG_ALGS; i++) {
++      if (strcasecompare(algname, kSignatureAlgorithmNames[i].name)) {
++        algs[*nalgs] = kSignatureAlgorithmNames[i].signature_algorithm;
++        (*nalgs)++;
++        found = TRUE;
++        break;
++      }
++    }
++
++    if (!found) {
++      failf(data, "Unknown signature hash algorithm: '%s'", algname);
++      return CURLE_BAD_FUNCTION_ARGUMENT;
++    }
++
++    if (end)
++      sigalgs = ++end;
++    else
++      break;
++  }
++
++  return CURLE_OK;
++}
++
++#endif
++
++
+ #if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
+ typedef uint32_t sslerr_t;
+ #else
+@@ -2650,6 +2770,183 @@ static const char *tls_rt_type(int type)
+   }
+ }
+ 
++#ifdef HAVE_LIBZ
++int DecompressZlibCert(SSL *ssl,
++                       CRYPTO_BUFFER** out,
++                       size_t uncompressed_len,
++                       const uint8_t* in,
++                       size_t in_len)
++{
++  z_stream strm;
++  uint8_t* data;
++  CRYPTO_BUFFER* decompressed = CRYPTO_BUFFER_alloc(&data, uncompressed_len);
++  if(!decompressed) {
++    return 0;
++  }
++
++  strm.zalloc = NULL;
++  strm.zfree = NULL;
++  strm.opaque = NULL;
++  strm.next_in = (Bytef *)in;
++  strm.avail_in = in_len;
++  strm.next_out = (Bytef *)data;
++  strm.avail_out = uncompressed_len;
++
++  if(inflateInit(&strm) != Z_OK) {
++    CRYPTO_BUFFER_free(decompressed);
++    return 0;
++  }
++
++  if(inflate(&strm, Z_FINISH) != Z_STREAM_END ||
++    strm.avail_in != 0 ||
++    strm.avail_out != 0) {
++    inflateEnd(&strm);
++    CRYPTO_BUFFER_free(decompressed);
++    return 0;
++  }
++
++  inflateEnd(&strm);
++  *out = decompressed;
++  return 1;
++}
++#endif
++
++#ifdef HAVE_BROTLI
++
++/* Taken from Chromium and adapted to C,
++ * see net/ssl/cert_compression.cc
++ */
++int DecompressBrotliCert(SSL* ssl,
++                         CRYPTO_BUFFER** out,
++                         size_t uncompressed_len,
++                         const uint8_t* in,
++                         size_t in_len) {
++  uint8_t* data;
++  CRYPTO_BUFFER* decompressed = CRYPTO_BUFFER_alloc(&data, uncompressed_len);
++  if (!decompressed) {
++    return 0;
++  }
++
++  size_t output_size = uncompressed_len;
++  if (BrotliDecoderDecompress(in_len, in, &output_size, data) !=
++          BROTLI_DECODER_RESULT_SUCCESS ||
++      output_size != uncompressed_len) {
++    CRYPTO_BUFFER_free(decompressed);
++    return 0;
++  }
++
++  *out = decompressed;
++  return 1;
++}
++#endif
++
++// curl-impersonate: decompress the zstd cert
++#ifdef HAVE_ZSTD
++int DecompressZstdCert(SSL* ssl,
++                       CRYPTO_BUFFER** out,
++                       size_t uncompressed_len,
++                       const uint8_t* in,
++                       size_t in_len) {
++  size_t result;
++  uint8_t* data;
++  CRYPTO_BUFFER* decompressed = CRYPTO_BUFFER_alloc(&data, uncompressed_len);
++  if (!decompressed) {
++    return 0;
++  }
++
++  // zstd returns the size of decompressed content
++  result = ZSTD_decompress(data, uncompressed_len, in, in_len);
++  if (ZSTD_isError(result)) {
++    CRYPTO_BUFFER_free(decompressed);
++    return 0;
++  }
++
++  *out = decompressed;
++  return 1;
++}
++
++#endif
++
++
++#if defined(HAVE_LIBZ) || defined(HAVE_BROTLI) || defined(HAVE_ZSTD)
++static struct {
++  char *alg_name;
++  uint16_t alg_id;
++  ssl_cert_compression_func_t compress;
++  ssl_cert_decompression_func_t decompress;
++} cert_compress_algs[] = {
++#ifdef HAVE_LIBZ
++  {"zlib", TLSEXT_cert_compression_zlib, NULL, DecompressZlibCert},
++#endif
++#ifdef HAVE_BROTLI
++  {"brotli", TLSEXT_cert_compression_brotli, NULL, DecompressBrotliCert},
++#endif
++#ifdef HAVE_ZSTD
++  {"zstd", TLSEXT_cert_compression_zstd, NULL, DecompressZstdCert},
++#endif
++};
++
++#define NUM_CERT_COMPRESSION_ALGS \
++  sizeof(cert_compress_algs) / sizeof(cert_compress_algs[0])
++
++/*
++ * curl-impersonate:
++ * Add support for TLS extension 27 - compress_certificate.
++ * This calls the BoringSSL-specific API SSL_CTX_add_cert_compression_alg
++ * for each algorithm specified in cert_compression, which is a comma separated list.
++ */
++static CURLcode add_cert_compression(struct Curl_easy *data,
++                                     SSL_CTX *ctx,
++                                     const char *algorithms)
++{
++  int i;
++  const char *s = algorithms;
++  char *alg_name;
++  size_t alg_name_len;
++  bool found;
++
++  while (s && s[0]) {
++    found = FALSE;
++
++    for(i = 0; i < NUM_CERT_COMPRESSION_ALGS; i++) {
++      alg_name = cert_compress_algs[i].alg_name;
++      alg_name_len = strlen(alg_name);
++      if(strlen(s) >= alg_name_len &&
++         strncasecompare(s, alg_name, alg_name_len) &&
++         (s[alg_name_len] == ',' || s[alg_name_len] == 0)) {
++        if(!SSL_CTX_add_cert_compression_alg(ctx,
++                    cert_compress_algs[i].alg_id,
++                    cert_compress_algs[i].compress,
++                    cert_compress_algs[i].decompress)) {
++          failf(data, "Error adding certificate compression algorithm '%s'",
++                alg_name);
++          return CURLE_SSL_CIPHER;
++        }
++        s += alg_name_len;
++        if(*s == ',')
++          s += 1;
++        found = TRUE;
++        break;
++      }
++    }
++
++    if(!found) {
++      failf(data, "Invalid compression algorithm list");
++      return CURLE_BAD_FUNCTION_ARGUMENT;
++    }
++  }
++
++  return CURLE_OK;
++}
++#else
++static CURLcode add_cert_compression(SSL_CTX *ctx, const char *algorithms)
++{
++  /* No compression algorithms are available. */
++  return CURLE_BAD_FUNCTION_ARGUMENT;
++}
++#endif
++
++
+ /*
+  * Our callback from the SSL/TLS layers.
+  */
+@@ -3571,6 +3868,7 @@ CURLcode Curl_ossl_ctx_init(struct ossl_ctx *octx,
+   const struct curl_blob *ssl_cert_blob = ssl_config->primary.cert_blob;
+   const char * const ssl_cert_type = ssl_config->cert_type;
+   const bool verifypeer = conn_config->verifypeer;
++  struct ssl_connect_data *connssl = cf->ctx;
+   char error_buffer[256];
+   struct alpn_spec alpns;
+ 
+@@ -3694,7 +3992,14 @@ CURLcode Curl_ossl_ctx_init(struct ossl_ctx *octx,
+   ctx_options = SSL_OP_ALL;
+ 
+ #ifdef SSL_OP_NO_TICKET
+-  ctx_options |= SSL_OP_NO_TICKET;
++  if(data->set.ssl_enable_ticket) {
++  /* curl-impersonate:
++   * Turn off SSL_OP_NO_TICKET, we want TLS extension 35 (session_ticket)
++   * to be present in the client hello. */
++    ctx_options &= ~SSL_OP_NO_TICKET;
++  } else {
++    ctx_options |= SSL_OP_NO_TICKET;
++  }
+ #endif
+ 
+ #ifdef SSL_OP_NO_COMPRESSION
+@@ -3751,6 +4056,20 @@ CURLcode Curl_ossl_ctx_init(struct ossl_ctx *octx,
+   SSL_CTX_set_mode(octx->ssl_ctx, SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
+ #endif
+ 
++  SSL_CTX_set_options(octx->ssl_ctx, SSL_OP_LEGACY_SERVER_CONNECT);
++  SSL_CTX_set_mode(octx->ssl_ctx,
++      SSL_MODE_CBC_RECORD_SPLITTING | SSL_MODE_ENABLE_FALSE_START);
++
++  /* curl-impersonate: Enable TLS extensions 18 - signed_certificate_timestamp. */
++  if(data->set.tls_signed_cert_timestamps) {
++    SSL_CTX_enable_signed_cert_timestamps(octx->ssl_ctx);
++  }
++
++  /* curl-impersonate: Enable TLS extensions 5 - status_request */
++  if(data->set.tls_status_request) {
++    SSL_CTX_enable_ocsp_stapling(octx->ssl_ctx);
++  }
++
+   if(ssl_cert || ssl_cert_blob || ssl_cert_type) {
+     if(!result &&
+        !cert_stuff(data, octx->ssl_ctx,
+@@ -3809,6 +4128,35 @@ CURLcode Curl_ossl_ctx_init(struct ossl_ctx *octx,
+     }
+   }
+ 
++#ifdef HAVE_SSL_CTX_SET_VERIFY_ALGORITHM_PREFS
++  {
++    uint16_t algs[MAX_SIG_ALGS];
++    size_t nalgs;
++    /* curl-impersonate: Set the signature algorithms (TLS extension 13).
++     * See net/socket/ssl_client_socket_impl.cc in Chromium's source. */
++    char *sig_hash_algs = conn_config->sig_hash_algs;
++    if (sig_hash_algs) {
++      CURLcode result = parse_sig_algs(data, sig_hash_algs, algs, &nalgs);
++      if (result)
++        return result;
++      if (!SSL_CTX_set_verify_algorithm_prefs(octx->ssl_ctx, algs, nalgs)) {
++        failf(data, "failed setting signature hash algorithms list: '%s'",
++              sig_hash_algs);
++        return CURLE_SSL_CIPHER;
++      }
++    } else {
++      /* Use defaults from Chrome. */
++      if (!SSL_CTX_set_verify_algorithm_prefs(octx->ssl_ctx,
++                                              default_sig_algs,
++                                              DEFAULT_SIG_ALGS_LENGTH)) {
++        failf(data, "failed setting signature hash algorithms list: '%s'",
++              sig_hash_algs);
++        return CURLE_SSL_CIPHER;
++      }
++    }
++  }
++#endif
++
+ #ifdef USE_OPENSSL_SRP
+   if(ssl_config->primary.username && Curl_auth_allowed_to_host(data)) {
+     char * const ssl_username = ssl_config->primary.username;
+@@ -3834,6 +4182,61 @@ CURLcode Curl_ossl_ctx_init(struct ossl_ctx *octx,
+   }
+ #endif
+ 
++  /* curl-impersonate:
++   * Configure BoringSSL to behave like Chrome. 
++   * See Constructor of SSLContext at net/socket/ssl_client_socket_impl.cc
++   * and SSLClientSocketImpl::Init()
++   * in the Chromium's source code. */
++
++  /* curl-impersonate: Enable TLS GREASE. */
++  if(data->set.tls_grease) {
++    SSL_CTX_set_grease_enabled(octx->ssl_ctx, 1);
++  }
++
++  /*
++   * curl-impersonate: Enable TLS extension permutation, enabled by default
++   * since Chrome 110.
++   */
++  if(data->set.ssl_permute_extensions) {
++    SSL_CTX_set_permute_extensions(octx->ssl_ctx, 1);
++  }
++
++  /* curl-impersonate: Set TLS extensions order. */
++  if(data->set.str[STRING_TLS_EXTENSION_ORDER]) {
++    SSL_CTX_set_extension_order(octx->ssl_ctx, data->set.str[STRING_TLS_EXTENSION_ORDER]);
++  }
++
++  if(data->set.str[STRING_TLS_DELEGATED_CREDENTIALS]) {
++    SSL_CTX_set_delegated_credentials(octx->ssl_ctx, data->set.str[STRING_TLS_DELEGATED_CREDENTIALS]);
++  }
++
++  if(data->set.tls_record_size_limit) {
++    SSL_CTX_set_record_size_limit(octx->ssl_ctx, data->set.tls_record_size_limit);
++  }
++
++  if(data->set.tls_key_shares_limit) {
++    SSL_CTX_set_key_shares_limit(octx->ssl_ctx, data->set.tls_key_shares_limit);
++  }
++
++  // curl-impersonate: Set key usage check
++  if(data->set.tls_key_usage_no_check) {
++    SSL_CTX_set_key_usage_check_enabled(octx->ssl_ctx, 0);
++  }else{
++    SSL_CTX_set_key_usage_check_enabled(octx->ssl_ctx, 1);
++  }
++
++  if(data->set.tls_use_firefox_tls13_ciphers) {
++    SSL_CTX_set_use_firefox_tls13_ciphers(octx->ssl_ctx, 1);
++  }
++
++  if(conn_config->cert_compression &&
++     add_cert_compression(data,
++                          octx->ssl_ctx,
++                          conn_config->cert_compression))
++    return CURLE_SSL_CIPHER;
++
++
++
+   /* OpenSSL always tries to verify the peer, this only says whether it should
+    * fail to connect if the verification fails, or if it should continue
+    * anyway. In the latter case the result of the verification is checked with
+@@ -3891,6 +4294,30 @@ CURLcode Curl_ossl_ctx_init(struct ossl_ctx *octx,
+ 
+   SSL_set_app_data(octx->ssl, ssl_user_data);
+ 
++
++#ifdef HAS_ALPN_OPENSSL
++  if(connssl->alps) {
++    size_t i;
++    struct alpn_proto_buf proto;
++
++    /* curl-impersonate: Set new ALPS codepoint before adding any ALPS settings */
++    if(data->set.tls_use_new_alps_codepoint) {
++      SSL_set_alps_use_new_codepoint(octx->ssl, 1);
++    }
++
++    for(i = 0; i < connssl->alps->count; ++i) {
++      /* curl-impersonate: Add the ALPS extension (17513) like Chrome does. */
++      // XXX: Firefox does not enable this.
++      SSL_add_application_settings(octx->ssl, connssl->alps->entries[i],
++                                   strlen(connssl->alps->entries[i]), NULL,
++                                   0);
++    }
++
++    Curl_alpn_to_proto_str(&proto, connssl->alps);
++    infof(data, VTLS_INFOF_ALPS_OFFER_1STR, proto.data);
++  }
++#endif
++
+ #if !defined(OPENSSL_NO_TLSEXT) && !defined(OPENSSL_NO_OCSP)
+   if(conn_config->verifystatus)
+     SSL_set_tlsext_status_type(octx->ssl, TLSEXT_STATUSTYPE_ocsp);
+diff --git a/lib/vtls/vtls.c b/lib/vtls/vtls.c
+index b44b764..1f2c3af 100644
+--- a/lib/vtls/vtls.c
++++ b/lib/vtls/vtls.c
+@@ -172,6 +172,17 @@ alpn_get_spec(http_majors allowed, bool use_alpn)
+      Avoid "http/1.0" because some servers do not support it. */
+   return &ALPN_SPEC_H11;
+ }
++
++static const struct alpn_spec *alps_get_spec(int httpwant, bool use_alps)
++{
++  if(!use_alps)
++    return NULL;
++#ifdef USE_HTTP2
++  if(httpwant >= CURL_HTTP_VERSION_2)
++    return &ALPN_SPEC_H2;
++#endif
++  return NULL;
++}
+ #endif /* USE_SSL */
+ 
+ 
+@@ -215,6 +226,8 @@ match_ssl_primary_config(struct Curl_easy *data,
+      strcasecompare(c1->cipher_list, c2->cipher_list) &&
+      strcasecompare(c1->cipher_list13, c2->cipher_list13) &&
+      strcasecompare(c1->curves, c2->curves) &&
++     strcasecompare(c1->sig_hash_algs, c2->sig_hash_algs) &&
++     strcasecompare(c1->cert_compression, c2->cert_compression) &&
+      strcasecompare(c1->CRLfile, c2->CRLfile) &&
+      strcasecompare(c1->pinned_key, c2->pinned_key))
+     return TRUE;
+@@ -259,6 +272,8 @@ static bool clone_ssl_primary_config(struct ssl_primary_config *source,
+   CLONE_STRING(cipher_list13);
+   CLONE_STRING(pinned_key);
+   CLONE_STRING(curves);
++  CLONE_STRING(sig_hash_algs);
++  CLONE_STRING(cert_compression);
+   CLONE_STRING(CRLfile);
+ #ifdef USE_TLS_SRP
+   CLONE_STRING(username);
+@@ -281,6 +296,8 @@ static void free_primary_ssl_config(struct ssl_primary_config *sslc)
+   Curl_safefree(sslc->ca_info_blob);
+   Curl_safefree(sslc->issuercert_blob);
+   Curl_safefree(sslc->curves);
++  Curl_safefree(sslc->sig_hash_algs);
++  Curl_safefree(sslc->cert_compression);
+   Curl_safefree(sslc->CRLfile);
+ #ifdef USE_TLS_SRP
+   Curl_safefree(sslc->username);
+@@ -304,6 +321,8 @@ CURLcode Curl_ssl_easy_config_complete(struct Curl_easy *data)
+   data->set.ssl.primary.cert_blob = data->set.blobs[BLOB_CERT];
+   data->set.ssl.primary.ca_info_blob = data->set.blobs[BLOB_CAINFO];
+   data->set.ssl.primary.curves = data->set.str[STRING_SSL_EC_CURVES];
++  data->set.ssl.primary.sig_hash_algs = data->set.str[STRING_SSL_SIG_HASH_ALGS];
++  data->set.ssl.primary.cert_compression = data->set.str[STRING_SSL_CERT_COMPRESSION];
+ #ifdef USE_TLS_SRP
+   data->set.ssl.primary.username = data->set.str[STRING_TLSAUTH_USERNAME];
+   data->set.ssl.primary.password = data->set.str[STRING_TLSAUTH_PASSWORD];
+@@ -455,7 +474,8 @@ static bool ssl_prefs_check(struct Curl_easy *data)
+ }
+ 
+ static struct ssl_connect_data *cf_ctx_new(struct Curl_easy *data,
+-                                           const struct alpn_spec *alpn)
++                                           const struct alpn_spec *alpn,
++                                           const struct alpn_spec *alps)
+ {
+   struct ssl_connect_data *ctx;
+ 
+@@ -466,6 +486,7 @@ static struct ssl_connect_data *cf_ctx_new(struct Curl_easy *data,
+ 
+   ctx->ssl_impl = Curl_ssl;
+   ctx->alpn = alpn;
++  ctx->alps = alps;
+   Curl_bufq_init2(&ctx->earlydata, CURL_SSL_EARLY_MAX, 1, BUFQ_OPT_NO_SPARES);
+   ctx->backend = calloc(1, ctx->ssl_impl->sizeof_ssl_backend_data);
+   if(!ctx->backend) {
+@@ -1661,8 +1682,8 @@ static CURLcode cf_ssl_create(struct Curl_cfilter **pcf,
+ 
+   DEBUGASSERT(data->conn);
+ 
+-  ctx = cf_ctx_new(data, alpn_get_spec(data->state.http_neg.wanted,
+-                                       conn->bits.tls_enable_alpn));
++  ctx = cf_ctx_new(data, alpn_get_spec(data->state.http_neg.wanted, conn->bits.tls_enable_alpn),
++                   alps_get_spec(data->state.http_neg.wanted, conn->bits.tls_enable_alps));
+   if(!ctx) {
+     result = CURLE_OUT_OF_MEMORY;
+     goto out;
+@@ -1712,6 +1733,7 @@ static CURLcode cf_ssl_proxy_create(struct Curl_cfilter **pcf,
+   struct ssl_connect_data *ctx;
+   CURLcode result;
+   bool use_alpn = conn->bits.tls_enable_alpn;
++  bool use_alps = conn->bits.tls_enable_alps;
+   http_majors allowed = CURL_HTTP_V1x;
+ 
+ #ifdef USE_HTTP2
+@@ -1721,7 +1743,8 @@ static CURLcode cf_ssl_proxy_create(struct Curl_cfilter **pcf,
+   }
+ #endif
+ 
+-  ctx = cf_ctx_new(data, alpn_get_spec(allowed, use_alpn));
++  ctx = cf_ctx_new(data, alpn_get_spec(allowed, use_alpn),
++                   alps_get_spec(allowed, use_alps));
+   if(!ctx) {
+     result = CURLE_OUT_OF_MEMORY;
+     goto out;
+diff --git a/lib/vtls/vtls.h b/lib/vtls/vtls.h
+index b751c37..be6499f 100644
+--- a/lib/vtls/vtls.h
++++ b/lib/vtls/vtls.h
+@@ -57,6 +57,8 @@ struct dynbuf;
+   "ALPN: server did not agree on a protocol. Uses default."
+ #define VTLS_INFOF_ALPN_OFFER_1STR    \
+   "ALPN: curl offers %s"
++#define VTLS_INFOF_ALPS_OFFER_1STR    \
++  "ALPS: offers %s"
+ #define VTLS_INFOF_ALPN_ACCEPTED      \
+   ALPN_ACCEPTED "%.*s"
+ 
+diff --git a/lib/vtls/vtls_int.h b/lib/vtls/vtls_int.h
+index 5dadbb1..177a581 100644
+--- a/lib/vtls/vtls_int.h
++++ b/lib/vtls/vtls_int.h
+@@ -110,6 +110,7 @@ struct ssl_connect_data {
+   const struct Curl_ssl *ssl_impl;  /* TLS backend for this filter */
+   struct ssl_peer peer;             /* peer the filter talks to */
+   const struct alpn_spec *alpn;     /* ALPN to use or NULL for none */
++  const struct alpn_spec *alps;     /* ALPS to use or NULL for none */
+   void *backend;                    /* vtls backend specific props */
+   struct cf_call_data call_data;    /* data handle used in current call */
+   struct curltime handshake_done;   /* time when handshake finished */
+diff --git a/libcurl.pc.in b/libcurl.pc.in
+index c0ba524..b5e9cb4 100644
+--- a/libcurl.pc.in
++++ b/libcurl.pc.in
+@@ -35,7 +35,7 @@ Description: Library to transfer files with HTTP, FTP, etc.
+ Version: @CURLVERSION@
+ Requires: @LIBCURL_PC_REQUIRES@
+ Requires.private: @LIBCURL_PC_REQUIRES_PRIVATE@
+-Libs: -L${libdir} -lcurl @LIBCURL_PC_LIBS@
++Libs: -L${libdir} -lcurl-impersonate @LIBCURL_PC_LIBS@
+ Libs.private: @LIBCURL_PC_LDFLAGS_PRIVATE@ @LIBCURL_PC_LIBS_PRIVATE@
+ Cflags: -I${includedir} @LIBCURL_PC_CFLAGS@
+ Cflags.private: @LIBCURL_PC_CFLAGS_PRIVATE@
+diff --git a/m4/curl-compilers.m4 b/m4/curl-compilers.m4
+index 15babf9..fb89332 100644
+--- a/m4/curl-compilers.m4
++++ b/m4/curl-compilers.m4
+@@ -393,42 +393,55 @@ AC_DEFUN([CURL_CONVERT_INCLUDE_TO_ISYSTEM], [
+   AC_REQUIRE([CURL_SHFUNC_SQUEEZE])dnl
+   AC_REQUIRE([CURL_CHECK_COMPILER])dnl
+   AC_MSG_CHECKING([convert -I options to -isystem])
+-  if test "$compiler_id" = "GNU_C" ||
+-    test "$compiler_id" = "CLANG" -o "$compiler_id" = "APPLECLANG"; then
+-    AC_MSG_RESULT([yes])
+-    tmp_has_include="no"
+-    tmp_chg_FLAGS="$CFLAGS"
+-    for word1 in $tmp_chg_FLAGS; do
+-      case "$word1" in
+-        -I*)
+-          tmp_has_include="yes"
+-          ;;
+-      esac
+-    done
+-    if test "$tmp_has_include" = "yes"; then
+-      tmp_chg_FLAGS=`echo "$tmp_chg_FLAGS" | "$SED" 's/^-I/ -isystem /g'`
+-      tmp_chg_FLAGS=`echo "$tmp_chg_FLAGS" | "$SED" 's/ -I/ -isystem /g'`
+-      CFLAGS="$tmp_chg_FLAGS"
+-      squeeze CFLAGS
+-    fi
+-    tmp_has_include="no"
+-    tmp_chg_FLAGS="$CPPFLAGS"
+-    for word1 in $tmp_chg_FLAGS; do
+-      case "$word1" in
+-        -I*)
+-          tmp_has_include="yes"
+-          ;;
+-      esac
+-    done
+-    if test "$tmp_has_include" = "yes"; then
+-      tmp_chg_FLAGS=`echo "$tmp_chg_FLAGS" | "$SED" 's/^-I/ -isystem /g'`
+-      tmp_chg_FLAGS=`echo "$tmp_chg_FLAGS" | "$SED" 's/ -I/ -isystem /g'`
+-      CPPFLAGS="$tmp_chg_FLAGS"
+-      squeeze CPPFLAGS
+-    fi
+-  else
++  case $host_os in
++  darwin*)
++    dnl curl-impersonate: On macos, clang gives priority to /usr/local/include
++    dnl over locations specified with -isystem for some unknown reason. In turn
++    dnl this causes clang to use the system's openssl, which conflicts with
++    dnl curl-impersonate's boringssl headers.
++    dnl To prevent that, disable curl's automatic conversion of -I flags to
++    dnl -isystem.
+     AC_MSG_RESULT([no])
+-  fi
++    ;;
++  *)
++    if test "$compiler_id" = "GNU_C" ||
++      test "$compiler_id" = "CLANG"; then
++      AC_MSG_RESULT([yes])
++      tmp_has_include="no"
++      tmp_chg_FLAGS="$CFLAGS"
++      for word1 in $tmp_chg_FLAGS; do
++        case "$word1" in
++          -I*)
++            tmp_has_include="yes"
++            ;;
++        esac
++      done
++      if test "$tmp_has_include" = "yes"; then
++        tmp_chg_FLAGS=`echo "$tmp_chg_FLAGS" | "$SED" 's/^-I/ -isystem /g'`
++        tmp_chg_FLAGS=`echo "$tmp_chg_FLAGS" | "$SED" 's/ -I/ -isystem /g'`
++        CFLAGS="$tmp_chg_FLAGS"
++        squeeze CFLAGS
++      fi
++      tmp_has_include="no"
++      tmp_chg_FLAGS="$CPPFLAGS"
++      for word1 in $tmp_chg_FLAGS; do
++        case "$word1" in
++          -I*)
++            tmp_has_include="yes"
++            ;;
++        esac
++      done
++      if test "$tmp_has_include" = "yes"; then
++        tmp_chg_FLAGS=`echo "$tmp_chg_FLAGS" | "$SED" 's/^-I/ -isystem /g'`
++        tmp_chg_FLAGS=`echo "$tmp_chg_FLAGS" | "$SED" 's/ -I/ -isystem /g'`
++        CPPFLAGS="$tmp_chg_FLAGS"
++        squeeze CPPFLAGS
++      fi
++    else
++      AC_MSG_RESULT([no])
++    fi
++    ;;
++  esac
+ ])
+ 
+ 
+diff --git a/src/Makefile.am b/src/Makefile.am
+index dcf1e37..049838b 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -46,7 +46,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/include        \
+               -I$(top_srcdir)/lib            \
+               -I$(top_srcdir)/src
+ 
+-bin_PROGRAMS = curl
++bin_PROGRAMS = curl-impersonate
+ 
+ if USE_CPPFLAG_CURL_STATICLIB
+ AM_CPPFLAGS += -DCURL_STATICLIB
+@@ -84,19 +84,19 @@ endif
+ curltool_unity.c: $(top_srcdir)/scripts/mk-unity.pl $(CURL_CFILES) $(curl_cfiles_gen) $(curl_CURLX)
+ 	@PERL@ $(top_srcdir)/scripts/mk-unity.pl $(srcdir) $(CURL_CFILES) $(curl_cfiles_gen) $(curl_CURLX) --exclude $(curl_EXCLUDE) > curltool_unity.c
+ 
+-nodist_curl_SOURCES = curltool_unity.c
+-curl_SOURCES = $(curl_EXCLUDE)
++nodist_curl_impersonate_SOURCES = curltool_unity.c
++curl_impersonate_SOURCES = $(curl_EXCLUDE)
+ CLEANFILES += curltool_unity.c
+ else
+ # CURL_FILES comes from Makefile.inc
+-curl_SOURCES = $(CURL_FILES) $(curl_cfiles_gen) $(curl_hfiles_gen)
++curl_impersonate_SOURCES = $(CURL_FILES) $(curl_cfiles_gen) $(curl_hfiles_gen)
+ endif
+ if HAVE_WINDRES
+-curl_SOURCES += $(CURL_RCFILES)
++curl_impersonate_SOURCES += $(CURL_RCFILES)
+ $(CURL_RCFILES): tool_version.h
+ endif
+ 
+-curl_LDFLAGS = $(AM_LDFLAGS) $(CURL_LDFLAGS_BIN)
++curl_impersonate_LDFLAGS = $(AM_LDFLAGS) $(CURL_LDFLAGS_BIN)
+ 
+ # This might hold -Werror
+ CFLAGS += @CURL_CFLAG_EXTRAS@
+@@ -104,7 +104,7 @@ CFLAGS += @CURL_CFLAG_EXTRAS@
+ # Prevent LIBS from being used for all link targets
+ LIBS = $(BLANK_AT_MAKETIME)
+ 
+-curl_LDADD = $(top_builddir)/lib/libcurl.la @LIBCURL_PC_LIBS_PRIVATE@
++curl_impersonate_LDADD = $(top_builddir)/lib/libcurl-impersonate.la @LIBCURL_PC_LIBS_PRIVATE@
+ 
+ # if unit tests are enabled, build a static library to link them with
+ if BUILD_UNITTESTS
+diff --git a/src/tool_cfgable.c b/src/tool_cfgable.c
+index 93ba139..37ccbc8 100644
+--- a/src/tool_cfgable.c
++++ b/src/tool_cfgable.c
+@@ -98,6 +98,14 @@ static void free_config_fields(struct OperationConfig *config)
+   curlx_safefree(config->proto_str);
+   curlx_safefree(config->proto_redir_str);
+ 
++  // curl-impersonate
++  Curl_safefree(config->ssl_sig_hash_algs);
++  Curl_safefree(config->ssl_cert_compression);
++  Curl_safefree(config->http2_pseudo_headers_order);
++  Curl_safefree(config->http2_settings);
++  Curl_safefree(config->http2_streams);
++  Curl_safefree(config->tls_extension_order);
++
+   urlnode = config->url_list;
+   while(urlnode) {
+     struct getout *next = urlnode->next;
+diff --git a/src/tool_cfgable.h b/src/tool_cfgable.h
+index 75fef60..3ed5952 100644
+--- a/src/tool_cfgable.h
++++ b/src/tool_cfgable.h
+@@ -135,12 +135,28 @@ struct OperationConfig {
+   char *etag_compare_file;
+   char *customrequest;
+   char *ssl_ec_curves;
++  char *ssl_sig_hash_algs;
++  char *ssl_cert_compression;
+   char *krblevel;
+   char *request_target;
++  char *http2_pseudo_headers_order;
++  char *http2_settings;
++  long http2_window_update;
++  long http2_stream_weight;
++  long http2_stream_exclusive;
++  char *http2_streams;
++  bool tls_grease;
++  char *tls_extension_order;
++  char *tls_delegated_credentials;
++  long tls_record_size_limit;
++  long tls_key_shares_limit;
++  bool tls_use_new_alps_codepoint;
++  bool tls_use_firefox_tls13_ciphers;
+   char *writeout;           /* %-styled format string to output */
+   struct curl_slist *quote;
+   struct curl_slist *postquote;
+   struct curl_slist *prequote;
++  bool ssl_permute_extensions;
+   struct curl_slist *headers;
+   struct curl_slist *proxyheaders;
+   struct tool_mime *mimeroot;
+@@ -197,6 +213,9 @@ struct OperationConfig {
+   long alivetime;           /* keepalive-time */
+   long alivecnt;            /* keepalive-cnt */
+   long gssapi_delegation;
++  bool alps;                      /* enable/disable TLS ALPS extension */
++  bool noticket;                  /* enable/disable TLS session ticket */
++  bool tls_signed_cert_timestamps;    /* curl-impersonate: enable extension 18 */
+   long expect100timeout_ms;
+   long happy_eyeballs_timeout_ms; /* happy eyeballs timeout in milliseconds.
+                                      0 is valid. default: CURL_HET_DEFAULT. */
+diff --git a/src/tool_getparam.c b/src/tool_getparam.c
+index a55973a..30885da 100644
+--- a/src/tool_getparam.c
++++ b/src/tool_getparam.c
+@@ -90,6 +90,7 @@ static ParameterError getstrn(char **str, const char *val,
+ static const struct LongShort aliases[]= {
+   {"abstract-unix-socket",       ARG_FILE, ' ', C_ABSTRACT_UNIX_SOCKET},
+   {"alpn",                       ARG_BOOL|ARG_NO|ARG_TLS, ' ', C_ALPN},
++  {"alps",                       ARG_BOOL, ' ', C_ALPS},  // curl-impersonate
+   {"alt-svc",                    ARG_STRG, ' ', C_ALT_SVC},
+   {"anyauth",                    ARG_BOOL, ' ', C_ANYAUTH},
+   {"append",                     ARG_BOOL, 'a', C_APPEND},
+@@ -100,6 +101,7 @@ static const struct LongShort aliases[]= {
+   {"cacert",                     ARG_FILE|ARG_TLS, ' ', C_CACERT},
+   {"capath",                     ARG_FILE|ARG_TLS, ' ', C_CAPATH},
+   {"cert",                       ARG_FILE|ARG_TLS, 'E', C_CERT},
++  {"cert-compression",           ARG_STRG|ARG_TLS, ' ', C_CERT_COMPRESSION},  // curl-impersonate
+   {"cert-status",                ARG_BOOL|ARG_TLS, ' ', C_CERT_STATUS},
+   {"cert-type",                  ARG_STRG|ARG_TLS, ' ', C_CERT_TYPE},
+   {"ciphers",                    ARG_STRG|ARG_TLS, ' ', C_CIPHERS},
+@@ -181,6 +183,12 @@ static const struct LongShort aliases[]= {
+   {"http1.1",                    ARG_NONE, ' ', C_HTTP1_1},
+   {"http2",                      ARG_NONE, ' ', C_HTTP2},
+   {"http2-prior-knowledge",      ARG_NONE, ' ', C_HTTP2_PRIOR_KNOWLEDGE},
++  {"http2-pseudo-headers-order", ARG_STRG, ' ', C_HTTP2_PSEUDO_HEADERS_ORDER},  // curl-impersonate
++  {"http2-settings",             ARG_STRG, ' ', C_HTTP2_SETTINGS},  // curl-impersonate
++  {"http2-stream-exclusive",     ARG_STRG, ' ', C_HTTP2_STREAM_EXCLUSIVE},  // curl-impersonate
++  {"http2-stream-weight",        ARG_STRG, ' ', C_HTTP2_STREAM_WEIGHT},  // curl-impersonate
++  {"http2-streams",              ARG_STRG, ' ', C_HTTP2_STREAMS},  // curl-impersonate
++  {"http2-window-update",        ARG_STRG, ' ', C_HTTP2_WINDOW_UPDATE},  // curl-impersonate
+   {"http3",                      ARG_NONE|ARG_TLS, ' ', C_HTTP3},
+   {"http3-only",                 ARG_NONE|ARG_TLS, ' ', C_HTTP3_ONLY},
+   {"ignore-content-length",      ARG_BOOL, ' ', C_IGNORE_CONTENT_LENGTH},
+@@ -305,6 +313,7 @@ static const struct LongShort aliases[]= {
+   {"sessionid",                  ARG_BOOL|ARG_NO, ' ', C_SESSIONID},
+   {"show-error",                 ARG_BOOL, 'S', C_SHOW_ERROR},
+   {"show-headers",               ARG_BOOL, 'i', C_SHOW_HEADERS},
++  {"signature-hashes",           ARG_STRG, ' ', C_SIGNATURE_HASHES}, // curl-impersonate
+   {"silent",                     ARG_BOOL, 's', C_SILENT},
+   {"skip-existing",              ARG_BOOL, ' ', C_SKIP_EXISTING},
+   {"socks4",                     ARG_STRG, ' ', C_SOCKS4},
+@@ -341,8 +350,18 @@ static const struct LongShort aliases[]= {
+   {"tftp-blksize",               ARG_STRG, ' ', C_TFTP_BLKSIZE},
+   {"tftp-no-options",            ARG_BOOL, ' ', C_TFTP_NO_OPTIONS},
+   {"time-cond",                  ARG_STRG, 'z', C_TIME_COND},
++  {"tls-delegated-credentials",  ARG_STRG, ' ', C_TLS_DELEGATED_CREDENTIALS},  // curl-impersonate
+   {"tls-earlydata",              ARG_BOOL|ARG_TLS, ' ', C_TLS_EARLYDATA},
++  {"tls-extension-order",        ARG_STRG, ' ', C_TLS_EXTENSION_ORDER},  // curl-impersonate
++  {"tls-grease",                 ARG_BOOL, ' ', C_TLS_GREASE},  // curl-impersonate
++  {"tls-key-shares-limit",       ARG_STRG, ' ', C_TLS_KEY_SHARES_LIMIT},  // curl-impersonate
+   {"tls-max",                    ARG_STRG|ARG_TLS, ' ', C_TLS_MAX},
++  {"tls-permute-extensions",     ARG_BOOL, ' ', C_TLS_PERMUTE_EXTENSIONS},  // curl-impersonate
++  {"tls-record-size-limit",      ARG_STRG, ' ', C_TLS_RECORD_SIZE_LIMIT},  // curl-impersonate
++  {"tls-session-ticket",         ARG_BOOL, ' ', C_TLS_SESSION_TICKET},  // curl-impersonate
++  {"tls-signed-cert-timestamps", ARG_BOOL, ' ', C_TLS_SIGNED_CERT_TIMESTAMPS}, // curl-impersonate
++  {"tls-use-firefox-tls13-ciphers", ARG_BOOL, ' ', C_TLS_USE_FIREFOX_TLS13_CIPHERS},  // curl-impersonate
++  {"tls-use-new-alps-codepoint", ARG_BOOL, ' ', C_TLS_USE_NEW_ALPS_CODEPOINT},  // curl-impersonate
+   {"tls13-ciphers",              ARG_STRG|ARG_TLS, ' ', C_TLS13_CIPHERS},
+   {"tlsauthtype",                ARG_STRG|ARG_TLS, ' ', C_TLSAUTHTYPE},
+   {"tlspassword",                ARG_STRG|ARG_TLS, ' ', C_TLSPASSWORD},
+@@ -1864,7 +1883,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
+         /* if given a blank string, make it NULL again */
+         curlx_safefree(config->doh_url);
+       break;
+-    case C_CIPHERS: /* -- ciphers */
++    case C_CIPHERS: /* --ciphers */
+       err = getstr(&config->cipher_list, nextarg, DENY_BLANK);
+       break;
+     case C_DNS_INTERFACE: /* --dns-interface */
+@@ -1913,6 +1932,9 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
+     case C_ALPN: /* --alpn */
+       config->noalpn = !toggle;
+       break;
++    case C_ALPS:  /* --alps curl-impersonate */
++      config->alps = toggle;
++      break;
+     case C_LIMIT_RATE: /* --limit-rate */
+       err = GetSizeParameter(global, nextarg, "rate", &value);
+       if(!err) {
+@@ -2294,6 +2316,36 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
+     case C_TLS_MAX: /* --tls-max */
+       err = str2tls_max(&config->ssl_version_max, nextarg);
+       break;
++    case C_TLS_SIGNED_CERT_TIMESTAMPS:
++      config->tls_signed_cert_timestamps = toggle;
++      break;
++    case C_TLS_SESSION_TICKET:  /* --tls-session-ticket curl-impersonate */
++      config->noticket = (!toggle)?TRUE:FALSE;
++      break;
++    case C_TLS_PERMUTE_EXTENSIONS:  /* --tls-permute-extensions curl-impersonate */
++      config->ssl_permute_extensions = toggle;
++      break;
++    case C_TLS_EXTENSION_ORDER:  /* --tls-extension-order curl-impersonate */
++      err = getstr(&config->tls_extension_order, nextarg, ALLOW_BLANK);
++      break;
++    case C_TLS_DELEGATED_CREDENTIALS:
++      err = getstr(&config->tls_delegated_credentials, nextarg, ALLOW_BLANK);
++      break;
++    case C_TLS_RECORD_SIZE_LIMIT:
++      err = str2unum(&config->tls_record_size_limit, nextarg);
++      break;
++    case C_TLS_KEY_SHARES_LIMIT:
++      err = str2unum(&config->tls_key_shares_limit, nextarg);
++      break;
++    case C_TLS_GREASE:  /* --tls-grease curl-impersonate */
++      config->tls_grease = toggle;
++      break;
++    case C_TLS_USE_NEW_ALPS_CODEPOINT: /* --tls-use-new-alps-codepoint curl-impersonate */
++      config->tls_use_new_alps_codepoint = toggle;
++      break;
++    case C_TLS_USE_FIREFOX_TLS13_CIPHERS: /* --tls-use-new-alps-codepoint curl-impersonate */
++      config->tls_use_firefox_tls13_ciphers = toggle;
++      break;
+     case C_SUPPRESS_CONNECT_HEADERS: /* --suppress-connect-headers */
+       config->suppress_connect_headers = toggle;
+       break;
+@@ -2343,6 +2395,39 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
+         return PARAM_LIBCURL_DOESNT_SUPPORT;
+       sethttpver(global, config, CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE);
+       break;
++    case C_HTTP2_PSEUDO_HEADERS_ORDER: /* --http2-pseudo-headers-order curl-impersonate */
++      if(!feature_http2)
++        return PARAM_LIBCURL_DOESNT_SUPPORT;
++      err = getstr(&config->http2_pseudo_headers_order, nextarg, ALLOW_BLANK);
++      break;
++    case C_HTTP2_SETTINGS:  /* --http2-settings curl-impersonate */
++      if(!feature_http2)
++        return PARAM_LIBCURL_DOESNT_SUPPORT;
++      err = getstr(&config->http2_settings, nextarg, ALLOW_BLANK);
++      break;
++    case C_HTTP2_STREAM_EXCLUSIVE:
++      if(!feature_http2)
++        return PARAM_LIBCURL_DOESNT_SUPPORT;
++      err = str2num(&config->http2_stream_exclusive, nextarg);
++      if(config->http2_stream_exclusive < 0) return PARAM_BAD_NUMERIC;
++      break;
++    case C_HTTP2_STREAM_WEIGHT:
++      if(!feature_http2)
++        return PARAM_LIBCURL_DOESNT_SUPPORT;
++      err = str2num(&config->http2_stream_weight, nextarg);
++      if(config->http2_stream_weight < 0) return PARAM_BAD_NUMERIC;
++      break;
++    case C_HTTP2_WINDOW_UPDATE:  /* --http2-window-update curl-impersonate */
++      if(!feature_http2)
++        return PARAM_LIBCURL_DOESNT_SUPPORT;
++      err = str2num(&config->http2_window_update, nextarg);
++      if(config->http2_window_update < -1) return PARAM_BAD_NUMERIC;
++      break;
++    case C_HTTP2_STREAMS:  /* --http2-streams curl-impersonate */
++      if(!feature_http2)
++        return PARAM_LIBCURL_DOESNT_SUPPORT;
++      err = getstr(&config->http2_streams, nextarg, ALLOW_BLANK);
++      break;
+     case C_HTTP3: /* --http3: */
+       /* Try HTTP/3, allow fallback */
+       if(!feature_http3)
+@@ -2477,6 +2562,9 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
+       GetFileAndPassword(nextarg, &config->cert, &config->key_passwd);
+       cleanarg(clearthis);
+       break;
++    case C_CERT_COMPRESSION:  /* --cert-compression curl-impersonate */
++      err = getstr(&config->ssl_cert_compression, nextarg, ALLOW_BLANK);
++      break;
+     case C_CACERT: /* --cacert */
+       err = getstr(&config->cacert, nextarg, DENY_BLANK);
+       break;
+@@ -2885,6 +2973,9 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
+     case C_SKIP_EXISTING: /* --skip-existing */
+       config->skip_existing = toggle;
+       break;
++    case C_SIGNATURE_HASHES: /* --signature-hashes */
++      err = getstr(&config->ssl_sig_hash_algs, nextarg, ALLOW_BLANK);
++      break;
+     case C_SHOW_ERROR: /* --show-error */
+       global->showerror = toggle;
+       break;
+diff --git a/src/tool_getparam.h b/src/tool_getparam.h
+index d770e26..fc28776 100644
+--- a/src/tool_getparam.h
++++ b/src/tool_getparam.h
+@@ -31,6 +31,7 @@
+ typedef enum {
+   C_ABSTRACT_UNIX_SOCKET,
+   C_ALPN,
++  C_ALPS,
+   C_ALT_SVC,
+   C_ANYAUTH,
+   C_APPEND,
+@@ -41,6 +42,7 @@ typedef enum {
+   C_CACERT,
+   C_CAPATH,
+   C_CERT,
++  C_CERT_COMPRESSION,
+   C_CERT_STATUS,
+   C_CERT_TYPE,
+   C_CIPHERS,
+@@ -122,6 +124,12 @@ typedef enum {
+   C_HTTP1_1,
+   C_HTTP2,
+   C_HTTP2_PRIOR_KNOWLEDGE,
++  C_HTTP2_PSEUDO_HEADERS_ORDER,
++  C_HTTP2_SETTINGS,
++  C_HTTP2_STREAM_EXCLUSIVE,
++  C_HTTP2_STREAM_WEIGHT,
++  C_HTTP2_STREAMS,
++  C_HTTP2_WINDOW_UPDATE,
+   C_HTTP3,
+   C_HTTP3_ONLY,
+   C_IGNORE_CONTENT_LENGTH,
+@@ -241,6 +249,7 @@ typedef enum {
+   C_SESSIONID,
+   C_SHOW_ERROR,
+   C_SHOW_HEADERS,
++  C_SIGNATURE_HASHES,
+   C_SILENT,
+   C_SKIP_EXISTING,
+   C_SOCKS4,
+@@ -274,7 +283,17 @@ typedef enum {
+   C_TFTP_NO_OPTIONS,
+   C_TIME_COND,
+   C_TLS_EARLYDATA,
++  C_TLS_DELEGATED_CREDENTIALS,
++  C_TLS_EXTENSION_ORDER,
++  C_TLS_GREASE,
++  C_TLS_KEY_SHARES_LIMIT,
+   C_TLS_MAX,
++  C_TLS_PERMUTE_EXTENSIONS,
++  C_TLS_RECORD_SIZE_LIMIT,
++  C_TLS_SESSION_TICKET,
++  C_TLS_SIGNED_CERT_TIMESTAMPS,
++  C_TLS_USE_FIREFOX_TLS13_CIPHERS,
++  C_TLS_USE_NEW_ALPS_CODEPOINT,
+   C_TLS13_CIPHERS,
+   C_TLSAUTHTYPE,
+   C_TLSPASSWORD,
+diff --git a/src/tool_listhelp.c b/src/tool_listhelp.c
+index b69cd89..ec131aa 100644
+--- a/src/tool_listhelp.c
++++ b/src/tool_listhelp.c
+@@ -111,6 +111,27 @@ const struct helptxt helptext[] = {
+   {"    --curves <list>",
+    "(EC) TLS key exchange algorithms to request",
+    CURLHELP_TLS},
++  {"    --signature-hashes <algorithm list>",
++   "TLS signature hash algorithm(s) to use",
++   CURLHELP_TLS},
++  {"    --cert-compression <algorithm list>",
++   "TLS cert compressions algorithm(s) to use",
++   CURLHELP_TLS},
++  {"    --no-tls-session-ticket",
++   "Disable the TLS session ticket extension",
++   CURLHELP_TLS},
++  {"    --http2-pseudo-headers-order",
++   "Change the order of the HTTP2 pseudo headers",
++   CURLHELP_HTTP},
++  {"    --http2-settings",
++   "Change the order and values of the HTTP2 settings frame, e.g. 1:65536;2:0;4:6291456;6:262144",
++   CURLHELP_HTTP},
++  {"    --http2-window-update",
++   "Change the initial value for window update",
++   CURLHELP_HTTP},
++  {"    --tls-permute-extensions",
++   "Enable BoringSSL TLS extensions permutations on client hello",
++   CURLHELP_TLS},
+   {"-d, --data <data>",
+    "HTTP POST data",
+    CURLHELP_IMPORTANT | CURLHELP_HTTP | CURLHELP_POST | CURLHELP_UPLOAD},
+@@ -411,6 +432,9 @@ const struct helptxt helptext[] = {
+   {"    --no-alpn",
+    "Disable the ALPN TLS extension",
+    CURLHELP_TLS | CURLHELP_HTTP},
++  {"    --alps",
++   "Enable the ALPS TLS extension",
++   CURLHELP_TLS | CURLHELP_HTTP},
+   {"-N, --no-buffer",
+    "Disable buffering of the output stream",
+    CURLHELP_OUTPUT},
+diff --git a/src/tool_operate.c b/src/tool_operate.c
+index 426d1de..f60c51a 100644
+--- a/src/tool_operate.c
++++ b/src/tool_operate.c
+@@ -1111,6 +1111,36 @@ static CURLcode config2setopts(struct GlobalConfig *global,
+       errorf(global, "HTTP/0.9 is not supported in this build");
+       return result;
+     }
++    if(config->http2_pseudo_headers_order)
++      my_setopt_str(curl,
++                    CURLOPT_HTTP2_PSEUDO_HEADERS_ORDER,
++                    config->http2_pseudo_headers_order);
++
++    if(config->http2_settings)
++      my_setopt_str(curl,
++                    CURLOPT_HTTP2_SETTINGS,
++                    config->http2_settings);
++
++    if(config->http2_window_update)
++      my_setopt(curl,
++                CURLOPT_HTTP2_WINDOW_UPDATE,
++                config->http2_window_update);
++
++    if(config->http2_stream_exclusive)
++      my_setopt(curl,
++                CURLOPT_STREAM_EXCLUSIVE,
++                config->http2_stream_exclusive);
++
++    if(config->http2_stream_weight)
++      my_setopt(curl,
++                CURLOPT_STREAM_WEIGHT,
++                config->http2_stream_weight);
++
++    if(config->http2_streams)
++      my_setopt_str(curl,
++                    CURLOPT_HTTP2_STREAMS,
++                    config->http2_streams);
++
+ 
+   } /* (proto_http) */
+ 
+@@ -1263,6 +1293,14 @@ static CURLcode config2setopts(struct GlobalConfig *global,
+   if(config->ssl_ec_curves)
+     my_setopt_str(curl, CURLOPT_SSL_EC_CURVES, config->ssl_ec_curves);
+ 
++  if(config->ssl_sig_hash_algs)
++    my_setopt_str(curl, CURLOPT_SSL_SIG_HASH_ALGS,
++                  config->ssl_sig_hash_algs);
++
++  if(config->ssl_cert_compression)
++    my_setopt_str(curl, CURLOPT_SSL_CERT_COMPRESSION,
++                  config->ssl_cert_compression);
++
+   if(config->writeout)
+     my_setopt_long(curl, CURLOPT_CERTINFO, 1);
+ 
+@@ -1457,10 +1495,43 @@ static CURLcode config2setopts(struct GlobalConfig *global,
+   if(config->proxy_cipher13_list) {
+     result = res_setopt_str(curl, CURLOPT_PROXY_TLS13_CIPHERS,
+                             config->proxy_cipher13_list);
++
+     if(result == CURLE_NOT_BUILT_IN)
+       warnf(global, "ignoring %s, not supported by libcurl with %s",
+             "--proxy-tls13-ciphers", ssl_backend());
+   }
++  /* curl-impersonate */
++  if(config->ssl_permute_extensions)
++    my_setopt(curl, CURLOPT_SSL_PERMUTE_EXTENSIONS, 1L);
++
++  /* curl-impersonate */
++  if(config->tls_grease)
++    my_setopt(curl, CURLOPT_TLS_GREASE, 1L);
++
++  /* curl-impersonate */
++  if(config->tls_extension_order)
++    // printf("setting is %s\n", config->tls_extension_order);
++    my_setopt_str(curl, CURLOPT_TLS_EXTENSION_ORDER, config->tls_extension_order);
++
++  /* curl-impersonate */
++  if (config->tls_use_new_alps_codepoint)
++    my_setopt(curl, CURLOPT_TLS_USE_NEW_ALPS_CODEPOINT, 1L);
++
++  /* curl-impersonate */
++  if (config->tls_use_firefox_tls13_ciphers)
++    my_setopt(curl, CURLOPT_TLS_USE_FIREFOX_TLS13_CIPHERS, 1L);
++
++  /* curl-impersonate */
++  if(config->tls_delegated_credentials)
++    my_setopt_str(curl, CURLOPT_TLS_DELEGATED_CREDENTIALS, config->tls_delegated_credentials);
++ 
++  /* curl-impersonate */
++  if(config->tls_record_size_limit)
++    my_setopt(curl, CURLOPT_TLS_RECORD_SIZE_LIMIT, config->tls_record_size_limit);
++ 
++  /* curl-impersonate */
++  if(config->tls_key_shares_limit)
++    my_setopt(curl, CURLOPT_TLS_KEY_SHARES_LIMIT, config->tls_key_shares_limit);
+ 
+   /* new in libcurl 7.9.2: */
+   if(config->disable_epsv)
+@@ -1660,6 +1731,22 @@ static CURLcode config2setopts(struct GlobalConfig *global,
+     my_setopt_long(curl, CURLOPT_SSL_ENABLE_ALPN, 0);
+   }
+ 
++  if(config->alps) {
++    my_setopt(curl, CURLOPT_SSL_ENABLE_ALPS, 1L);
++  }
++
++  if (config->noticket) {
++    my_setopt(curl, CURLOPT_SSL_ENABLE_TICKET, 0L);
++  }
++
++  // curl-impersonate
++  if(config->tls_signed_cert_timestamps) {
++    my_setopt(curl, CURLOPT_TLS_SIGNED_CERT_TIMESTAMPS, 1L);
++  }
++
++  // curl-impersonate: always enable this
++  my_setopt(curl, CURLOPT_TLS_STATUS_REQUEST, 1L);
++
+   /* new in 7.40.0, abstract support added in 7.53.0 */
+   if(config->unix_socket_path) {
+     if(config->abstract_unix_socket) {
+diff --git a/src/tool_setopt.c b/src/tool_setopt.c
+index cd3aeab..f573d59 100644
+--- a/src/tool_setopt.c
++++ b/src/tool_setopt.c
+@@ -160,6 +160,9 @@ static const struct NameValue setopt_nv_CURLNONZERODEFAULTS[] = {
+   NV1(CURLOPT_SSL_VERIFYHOST, 1),
+   NV1(CURLOPT_SSL_ENABLE_NPN, 1),
+   NV1(CURLOPT_SSL_ENABLE_ALPN, 1),
++  NV1(CURLOPT_SSL_ENABLE_TICKET, 1),
++  NV1(CURLOPT_SSL_PERMUTE_EXTENSIONS, 1),
++  NV1(CURLOPT_TLS_STATUS_REQUEST, 1),
+   NV1(CURLOPT_TCP_NODELAY, 1),
+   NV1(CURLOPT_PROXY_SSL_VERIFYPEER, 1),
+   NV1(CURLOPT_PROXY_SSL_VERIFYHOST, 1),

--- a/pkgs/by-name/cu/curl-impersonate/package.nix
+++ b/pkgs/by-name/cu/curl-impersonate/package.nix
@@ -17,15 +17,7 @@ let
     owner = "lexiforest";
     repo = "curl-impersonate";
     tag = "v${version}";
-    hash = "sha256-XbXd1Lf7bnI5vpESMK44ScOJYS4fEQq22lJ2rmy/koI=";
-
-    postFetch = ''
-      # Fix patch to not refer to the dev version.
-      substituteInPlace "$out"/patches/curl.patch --replace-fail 8.13.0-DEV 8.13.0
-
-      # Remove lines related to scripts/singleuse.pl
-      sed -i -E '4329,4340d' "$out"/patches/curl.patch
-    '';
+    hash = "sha256-sw/qn7c1ZFCQNRK9XUxttf1KjXK8fEB9Owcj99K1ihg=";
   };
 
   boringssl-commit = "673e61fc215b178a90c0e67858bbf162c8158993"; # BORING_SSL_COMMIT in Makefile.in
@@ -153,12 +145,19 @@ let
             }/curl-${curl-version}.tar.xz"
           ];
           hash = curl-hash;
+
         };
+
+        outputs = [
+          "bin"
+          "dev"
+          "out"
+        ];
 
         nativeBuildInputs = old.nativeBuildInputs ++ [ installShellFiles ];
 
         patches = old.patches or [ ] ++ [
-          "${curl-impersonate-src}/patches/curl.patch"
+          ./curl.patch
         ];
 
         configureFlags = old.configureFlags or [ ] ++ [
@@ -171,7 +170,7 @@ let
           "--disable-docs"
         ];
 
-        postInstall =
+        /*postInstall =
           old.postInstall or ""
           + ''
             # Rename curl binary and install other scripts
@@ -198,7 +197,7 @@ let
 
             # Install zsh and fish completions
             installShellCompletion curl-impersonate.{zsh,fish}
-          '';
+          '';*/
 
         passthru = {
           boringssl = boringssl-wrapper;

--- a/pkgs/by-name/cu/curl-impersonate/package.nix
+++ b/pkgs/by-name/cu/curl-impersonate/package.nix
@@ -88,6 +88,7 @@ let
     }).overrideAttrs
       (old: {
         cmakeFlags = old.cmakeFlags ++ [
+          (lib.cmakeBool "ENABLE_STATIC_LIB" true)
           (lib.cmakeBool "ENABLE_LIB_ONLY" true)
           (lib.cmakeBool "ENABLE_OPENSSL" false)
           (lib.cmakeBool "ENABLE_BORINGSSL" true)
@@ -162,10 +163,12 @@ let
 
         configureFlags = old.configureFlags or [ ] ++ [
           "LIBS=-lstdc++"
+          "--with-ngtcp2=${lib.getDev patched-ngtcp2}"
           "--with-nghttp2=${lib.getDev patched-nghttp2}"
           "--enable-ech"
           "--enable-ipv6"
           "USE_CURL_SSLKEYLOGFILE=true"
+          "--disable-docs"
         ];
 
         postInstall =


### PR DESCRIPTION
Fixes some compilation errors, but still fails with a linking error:

```/nix/store/wcv8n2k53w8sbffpf716gxj6mjb5jf26-binutils-2.44/bin/ld: ../lib/.libs/libcurl.so: undefined reference to `ngtcp2_crypto_client_initial_cb'```

Hope this helps!

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
